### PR TITLE
fix: externalised json output as bool to represent unoplat pydantic s…

### DIFF
--- a/unoplat-code-confluence/unoplat_code_confluence/configuration/external_config.py
+++ b/unoplat-code-confluence/unoplat_code_confluence/configuration/external_config.py
@@ -40,6 +40,7 @@ class AppConfig(BaseModel):
     llm_provider_config: Dict[str, Any]
     handlers: List[Dict[str, Any]] = Field(default_factory=list,alias="logging_handlers")
     parallisation: int = 1
+    json_output: bool = False
  
     @field_validator('programming_language')
     def check_programming_language(cls, value, info:ValidationInfo):

--- a/unoplat-code-confluence/unoplat_code_confluence/summary_parser/codebase_summary.py
+++ b/unoplat-code-confluence/unoplat_code_confluence/summary_parser/codebase_summary.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import deque
+import datetime
 from itertools import cycle
 import sys
 from typing import Dict, List
@@ -33,8 +34,9 @@ class CodebaseSummaryParser:
         self.dspy_pipeline_codebase: CodeConfluenceCodebaseModule = dspy_pipeline_codebase
         #TODO: we will be externalise the different llms that can be used at all dspy pipelines and within dspy pipelines once dspy switches to litellm
         self.provider_list =self.init_dspy_lm(app_config.llm_provider_config,app_config.parallisation)
-        
-    
+        self.json_output = app_config.json_output
+        self.codebase_name = app_config.codebase_name
+
     def init_dspy_lm(self,llm_config: dict,parallisation: int):
         #todo define a switch case
         llm_provider = next(iter(llm_config.keys()))
@@ -103,10 +105,14 @@ class CodebaseSummaryParser:
         unoplat_codebase_summary.codebase_summary = dspy_codebase_summary.summary
         unoplat_codebase_summary.codebase_objective = dspy_codebase_summary.answer
         unoplat_codebase_summary.codebase_package = root_package_summaries
-        json_unoplat_codebase_summary = unoplat_codebase_summary.model_dump_json()
-        # write to file
-        with open("unoplat_codebase_summary_dspy_2.json", "w") as f:
-            f.write(json_unoplat_codebase_summary)
+
+        # if json_output is true, then write to a json file
+        if self.json_output:
+            json_unoplat_codebase_summary = unoplat_codebase_summary.model_dump_json()
+            # write to file
+            current_timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            with open(f"{self.codebase_name}_{current_timestamp}.json", "w") as f:
+                f.write(json_unoplat_codebase_summary)
 
         # write to md file
         #todo: pydantic out to a file of unoplat codebase summary


### PR DESCRIPTION
### **User description**
…chema in json


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new boolean flag `json_output` in the `AppConfig` class to control JSON output.
- Enhanced the `codebase_summary` module to conditionally write JSON output to a file based on the `json_output` flag.
- JSON output file is named using the `codebase_name` and a timestamp for uniqueness.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external_config.py</strong><dd><code>Add `json_output` boolean flag to AppConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence/unoplat_code_confluence/configuration/external_config.py

<li>Added a new boolean field <code>json_output</code> to <code>AppConfig</code>.<br> <li> Default value for <code>json_output</code> is set to <code>False</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/117/files#diff-128052b36c831604e8f70ea0b6b41b9d0c5bc898c6c746f93ea38d8732fc8952">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>codebase_summary.py</strong><dd><code>Implement conditional JSON output with timestamped filename</code></dd></summary>
<hr>

unoplat-code-confluence/unoplat_code_confluence/summary_parser/codebase_summary.py

<li>Imported <code>datetime</code> module.<br> <li> Added <code>json_output</code> and <code>codebase_name</code> attributes to the class.<br> <li> Conditional JSON file writing based on <code>json_output</code> flag.<br> <li> JSON file name includes a timestamp and <code>codebase_name</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/117/files#diff-ac6ed9ee27276a6d26b4f89c8c17158f502f649395946f50d7b1f424834edbed">+12/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

