### PR TITLE
fix: no base url for custom domain

### DIFF
--- a/code-confluence/docusaurus.config.js
+++ b/code-confluence/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
   url: 'https://docs.unoplat.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/unoplat-code-confluence/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/unoplat-677b70fe-0fa4ef9e2a-1b2468?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdjYzA5ZmYxNDRmNTg1YWU1MmY0YTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamF5Z2hpeWEtdW5vcGxhdC02NzdiNzBmZS0wZmE0ZWY5ZTJhLTFiMjQ2NyJ9.iIgQu78WKiOq9qMP8q3Xjna2MqXtfuP8t9ZdLbaU2Ws">Huly&reg;: <b>UNOPL-309</b></a></sub>