### PR TITLE
fix: add sanitized project name for coverage reports

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -102,10 +102,17 @@ jobs:
           uv sync --group test
           uv run pytest --cov=src/code_confluence_flow_bridge --cov-report=html:coverage_reports --cov-report=xml:coverage.xml --cov-report=term-missing tests/ -v
 
+      - name: Set sanitized project name
+        id: sanitize
+        run: |
+          # Replace slashes with hyphens and set as output
+          SANITIZED_NAME=$(echo "${{ matrix.project }}" | tr '/' '-')
+          echo "project_name=$SANITIZED_NAME" >> $GITHUB_OUTPUT
+
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports-${{ matrix.project }}
+          name: coverage-reports-${{ steps.sanitize.outputs.project_name }}
           path: |
             ${{ matrix.project }}/coverage_reports/
           retention-days: 7


### PR DESCRIPTION
### **User description**
Add a step to sanitize the project name by replacing slashes with 
hyphens. This change ensures that the coverage report names are 
consistent and valid, improving the clarity and usability of the 
artifacts uploaded to GitHub.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Sanitize project names by replacing slashes with hyphens.

- Ensure consistent and valid coverage report artifact names.

- Improve clarity and usability of uploaded GitHub artifacts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_build.yaml</strong><dd><code>Sanitize project names and update artifact naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python_build.yaml

<li>Added a step to sanitize project names by replacing slashes with <br>hyphens.<br> <li> Updated the artifact upload step to use the sanitized project name.<br> <li> Improved naming consistency for coverage report artifacts.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/380/files#diff-acffa834ca92a0147495c1b31c0f6fbe52107d39165a10e37fcd2f4357f4ad31">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>