### PR TITLE
fix: prod docker compose path

### DIFF
--- a/.github/workflows/python_publish_release_management.yaml
+++ b/.github/workflows/python_publish_release_management.yaml
@@ -115,7 +115,7 @@ jobs:
             const yaml = require('js-yaml');
             
             // Read the docker-compose file
-            const filePath = '${{ matrix.path }}/prod-docker-compose.yml';
+            const filePath = 'prod-docker-compose.yml';
             const fileContent = fs.readFileSync(filePath, 'utf8');
             const compose = yaml.load(fileContent);
             


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the file path for the production Docker Compose file.

- Ensured compatibility with the correct file structure in workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_publish_release_management.yaml</strong><dd><code>Corrected file path in workflow script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python_publish_release_management.yaml

<li>Corrected the file path for the production Docker Compose file.<br> <li> Changed from a dynamic path to a static 'prod-docker-compose.yml'.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/391/files#diff-6a7b6722a1ce00109d0879380337a82dfc9dee67e92b3689838acaab01588735">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>