### PR TITLE
fix: backend state managemnt to share state cross-device/sessions

### DIFF
--- a/unoplat-code-confluence-frontend/src/lib/api.ts
+++ b/unoplat-code-confluence-frontend/src/lib/api.ts
@@ -133,3 +133,22 @@ export const deleteGitHubToken = async (): Promise<ApiResponse> => {
     throw handleApiError(error);
   }
 };
+
+/**
+ * Get flag status from the backend
+ * 
+ * @param flagName - Name of the flag to check
+ * @returns Promise with the flag status
+ */
+export interface FlagResponse {
+  status: boolean;
+}
+
+export const getFlagStatus = async (flagName: string): Promise<FlagResponse> => {
+  try {
+    const response: AxiosResponse<FlagResponse> = await apiClient.get(`/flags/${flagName}`);
+    return response.data;
+  } catch (error: unknown) {
+    throw handleApiError(error);
+  }
+};

--- a/unoplat-code-confluence-frontend/src/pages/SettingsPage.tsx
+++ b/unoplat-code-confluence-frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import GitHubTokenPopup from '../components/GitHubTokenPopup';
 import { Card, CardContent } from '../components/ui/card';
 import { Button } from '../components/ui/button';
@@ -22,13 +23,15 @@ export default function SettingsPage(): React.ReactElement {
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   
   const handleDeleteToken = async (): Promise<void> => {
     try {
       setIsDeleting(true);
       await deleteGitHubToken();
       setShowDeleteDialog(false);
-      localStorage.setItem('hasSubmittedToken', 'false');
+      // Invalidate and refetch the flag status
+      await queryClient.invalidateQueries({ queryKey: ['flags', 'isTokenSubmitted'] });
       toast({
         title: "Success",
         description: "Your GitHub token has been successfully removed",
@@ -73,7 +76,7 @@ export default function SettingsPage(): React.ReactElement {
               <div>
                 <h3 className="text-lg font-medium">GitHub Authentication</h3>
                 <p className="text-sm text-muted-foreground">
-                  Update or change your GitHub Personal Access Token.
+                  Update GitHub Personal Access Token.
                 </p>
               </div>
               <div className="flex items-center gap-2">

--- a/unoplat-code-confluence-frontend/src/routes/_app.tsx
+++ b/unoplat-code-confluence-frontend/src/routes/_app.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { createFileRoute, Outlet, useNavigate, useRouterState } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
 import GitHubTokenPopup from '../components/GitHubTokenPopup';
+import { getFlagStatus, FlagResponse } from '../lib/api';
 
 export const Route = createFileRoute('/_app')({
   component: AppComponent,
@@ -11,14 +13,21 @@ function AppComponent(): React.ReactElement {
   const navigate = useNavigate();
   const routerState = useRouterState();
   
+  // Query for token submission status
+  const { data: tokenStatus } = useQuery<FlagResponse>({
+    queryKey: ['flags', 'isTokenSubmitted'],
+    queryFn: () => getFlagStatus('isTokenSubmitted'),
+  });
+
+  // Show token popup if no token is present
   useEffect(() => {
-    // Check if token has been submitted before
-    const hasSubmittedToken = localStorage.getItem('hasSubmittedToken');
-    if (!hasSubmittedToken) {
+    if (tokenStatus && !tokenStatus.status) {
       setShowTokenPopup(true);
     }
-    
-    // If user is at root path '/', redirect to /onboarding
+  }, [tokenStatus]);
+
+  // Handle root path navigation
+  useEffect(() => {
     if (routerState.location.pathname === '/') {
       navigate({ to: '/onboarding' });
     }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced backend-driven flag management for cross-session state sharing.

- Replaced localStorage checks with React Query for token status.

- Updated components to handle token status dynamically via backend.

- Improved error handling and query invalidation for token-related actions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Added API function for backend flag status retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-frontend/src/lib/api.ts

<li>Added <code>getFlagStatus</code> API function to fetch flag status.<br> <li> Introduced <code>FlagResponse</code> interface for API response typing.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/421/files#diff-aa9be1dceecc846ac888a07d534d4d4634438f124d79bdbde4027c54502c9d2c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GitHubTokenPopup.tsx</strong><dd><code>Enhanced token submission with query invalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-frontend/src/components/GitHubTokenPopup.tsx

<li>Integrated React Query's <code>useQueryClient</code> for query invalidation.<br> <li> Updated token submission logic to invalidate and refetch flag status.<br> <li> Improved error handling during token submission.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/421/files#diff-24d102d9410ee9db13a5277a93b7a5256246ebd33c83e37d6caa6017913d685f">+20/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OnboardingPage.tsx</strong><dd><code>Refactored onboarding flow for backend-driven token status</code></dd></summary>
<hr>

unoplat-code-confluence-frontend/src/pages/OnboardingPage.tsx

<li>Replaced local token checks with backend-driven flag status.<br> <li> Added React Query for fetching and managing token status.<br> <li> Updated repository fetching logic to depend on backend flag.<br> <li> Improved token submission success handling with query invalidation.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/421/files#diff-78d40862faadf11a8c140f39c51d533c42c6958c4ffa860dac5976d04ea71f13">+24/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsPage.tsx</strong><dd><code>Updated settings page for backend token management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-frontend/src/pages/SettingsPage.tsx

<li>Integrated query invalidation for token deletion.<br> <li> Removed localStorage dependency for token status.<br> <li> Simplified token update description text.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/421/files#diff-9a714a44d250e9b10ba14d07096b089a25cfb7eae1e890accf6da16c4e422a1e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_app.tsx</strong><dd><code>Integrated backend-driven token status in app initialization</code></dd></summary>
<hr>

unoplat-code-confluence-frontend/src/routes/_app.tsx

<li>Added React Query for token status retrieval.<br> <li> Updated root path handling to depend on backend-driven flag.<br> <li> Removed localStorage checks for token submission.


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/421/files#diff-11b2fdc97ecd342b56ea7eb81af890cdf135c71daf602bae560f4856b7adcecb">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>