### PR TITLE
feat(codebase): add removable codebase forms when creating config

### DIFF
--- a/unoplat-code-confluence-frontend/src/components/custom/CodebaseForm.tsx
+++ b/unoplat-code-confluence-frontend/src/components/custom/CodebaseForm.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { z } from "zod";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, TrashIcon } from "lucide-react";
 import React from "react";
 
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
 
 // Extend the Zod schema to include nested structures if needed
 export const CodebaseSchema = z.object({
@@ -43,12 +44,14 @@ export interface CodebaseFormProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parentForm: any;
   disabled?: boolean;
+  onRemove?: () => void;
 }
 
 export function CodebaseForm({
   index,
   parentForm,
   disabled = false,
+  onRemove,
 }: CodebaseFormProps): React.ReactElement {
   // Helper to create field name with proper type
   const getFieldName = <K extends keyof Codebase>(fieldName: K): string => 
@@ -91,8 +94,6 @@ export function CodebaseForm({
 
   return (
     <div className="space-y-4 p-4 border rounded-md relative">
-      {/* Delete button is currently disabled and hidden as per requirements */}
-      {/*
       {onRemove && (
         <Button
           variant="ghost"
@@ -104,7 +105,6 @@ export function CodebaseForm({
           <TrashIcon className="h-4 w-4 text-destructive" />
         </Button>
       )}
-      */}
 
       <parentForm.Field
         name={getFieldName("codebase_folder")}

--- a/unoplat-code-confluence-frontend/src/components/custom/RepositoryConfigDialog.tsx
+++ b/unoplat-code-confluence-frontend/src/components/custom/RepositoryConfigDialog.tsx
@@ -288,38 +288,43 @@ export function RepositoryConfigDialog({
           form.handleSubmit();
         }}>
           <div className="py-4 space-y-6">
-            <form.Field 
-              name="codebases" 
+            <form.Field
+              name="codebases"
               mode="array"
             >
-              {(field) => (
-                <>
-                  {field.state.value.map((_, index: number) => (
-                    <CodebaseForm
-                      key={index}
-                      index={index}
-                      parentForm={form}
-                      disabled={existingCodebases.length > 0}
-                    />
-                  ))}
-                  {/* Hide Add Codebase button if editing existing config */}
-                  {existingCodebases.length === 0 && (
-                    <div className="flex justify-center mt-4">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        aria-label="Add Codebase"
-                        className="flex items-center justify-center bg-blue-50 text-blue-600 border-blue-200 hover:bg-blue-100"
-                        onClick={() => field.pushValue(defaultCodebase)}
-                      >
-                        <PlusIcon className="mr-2 h-4 w-4" />
-                        Add Codebase
-                      </Button>
-                    </div>
-                  )}
-                </>
-              )}
+              {(field) => {
+                const isCreating = existingCodebases.length === 0;
+                const allowRemove = isCreating && field.state.value.length > 1;
+                return (
+                  <>
+                    {field.state.value.map((_, index: number) => (
+                      <CodebaseForm
+                        key={index}
+                        index={index}
+                        parentForm={form}
+                        disabled={!isCreating}
+                        onRemove={allowRemove ? () => field.removeValue(index) : undefined}
+                      />
+                    ))}
+                    {/* Hide Add Codebase button if editing existing config */}
+                    {existingCodebases.length === 0 && (
+                      <div className="flex justify-center mt-4">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          aria-label="Add Codebase"
+                          className="flex items-center justify-center bg-blue-50 text-blue-600 border-blue-200 hover:bg-blue-100"
+                          onClick={() => field.pushValue(defaultCodebase)}
+                        >
+                          <PlusIcon className="mr-2 h-4 w-4" />
+                          Add Codebase
+                        </Button>
+                      </div>
+                    )}
+                  </>
+                );
+              }}
             </form.Field>
           </div>
 


### PR DESCRIPTION
Add onRemove callback to CodebaseForm to removing individual
codebase entries. Update RepositoryConfigDialog to allow removing
codebases only when creating a new configuration and more than one
codebase exists. Disable removal and addition controls when editing
existing configurations to prevent unintended changes. This improves
usability by allowing dynamic management of codebases during creation.