### PR TITLE
feat(sidebar): add collapsible groups for workspace and settings

### DIFF
--- a/unoplat-code-confluence-frontend/package.json
+++ b/unoplat-code-confluence-frontend/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.6",
     "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-collapsible": "^1.1.7",
     "@radix-ui/react-dialog": "^1.1.7",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",

--- a/unoplat-code-confluence-frontend/src/components/custom/AppSidebar.tsx
+++ b/unoplat-code-confluence-frontend/src/components/custom/AppSidebar.tsx
@@ -1,37 +1,41 @@
 import React from 'react'
-import { 
-  Sidebar, 
-  SidebarHeader, 
-  SidebarContent, 
-  SidebarFooter, 
-  SidebarMenu, 
-  SidebarMenuItem, 
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
+  SidebarMenu,
+  SidebarMenuItem,
   SidebarMenuButton,
-  SidebarRail
+  SidebarRail,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent
 } from '../ui/sidebar'
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent
+} from '../ui/collapsible'
 import { Link } from '@tanstack/react-router'
-import { FileCheck, Settings } from 'lucide-react'
+import { FileCheck, Settings, ChevronRight, LifeBuoy } from 'lucide-react'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { NavUser } from './NavUser'
 
 
-
-
-
 export function AppSidebar(): React.ReactElement {
-  // Use Zustand store for auth state
   const { user, tokenStatus } = useAuthStore()
+  
 
   // Only show user info in footer when token is valid and user data exists
   const showUserInfo = tokenStatus?.status && user
 
   return (
-    <Sidebar 
-      side="left" 
-      collapsible="icon" 
+    <Sidebar
+      side="left"
+      collapsible="icon"
       variant="sidebar"
       className="group max-w-[14rem] w-full"
-
     >
       <SidebarHeader>
         <div className="flex items-center gap-2 px-4 py-2">
@@ -39,38 +43,116 @@ export function AppSidebar(): React.ReactElement {
           <h1 className="font-semibold text-lg truncate bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">Code Confluence</h1>
         </div>
       </SidebarHeader>
-
       <SidebarContent>
-      <div className="px-2 space-y-1">
-
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild tooltip="GitHub Onboarding">
-              <Link to="/onboarding" className="flex w-full items-center gap-3 rounded-md px-4 py-2">
-                <FileCheck />
-                <span className="text-sm font-medium">Onboarding</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild tooltip="Settings">
-              <Link to="/settings" className="flex w-full items-center gap-3 rounded-md px-4 py-2">
-                <Settings />
-                <span className="text-sm font-medium">Settings</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
+        <div className="px-2 space-y-1">
+          {/* Workspace Setup Group */}
+          <Collapsible className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel
+                asChild
+                className="text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer group-data-[collapsible=icon]:!opacity-100 group-data-[collapsible=icon]:!mt-0"
+              >
+                <CollapsibleTrigger className="flex w-full items-center font-semibold group-data-[collapsible=icon]:justify-center">
+                  <FileCheck className="h-4 w-4" aria-hidden />
+                  <span className="ml-2 group-data-[collapsible=icon]:hidden">Workspace Setup</span>
+                  <ChevronRight className="ml-auto h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" aria-hidden />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent className="group-data-[collapsible=icon]:hidden">
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild tooltip="GitHub Onboarding">
+                        <Link to="/onboarding" className="flex w-full items-center rounded-md px-4 py-2 group-data-[collapsible=icon]:justify-center">
+                          <span className="text-sm font-medium">GitHub Onboarding</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
+          {/* Settings Group */}
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel
+                asChild
+                className="text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer group-data-[collapsible=icon]:!opacity-100 group-data-[collapsible=icon]:!mt-0"
+              >
+                <CollapsibleTrigger className="flex w-full items-center font-semibold group-data-[collapsible=icon]:justify-center">
+                  <Settings className="h-4 w-4" aria-hidden />
+                  <span className="ml-2 group-data-[collapsible=icon]:hidden">Settings</span>
+                  <ChevronRight className="ml-auto h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" aria-hidden />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent className="group-data-[collapsible=icon]:hidden">
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild tooltip="Settings">
+                        <Link to="/settings" className="flex w-full items-center rounded-md px-4 py-2 group-data-[collapsible=icon]:justify-center">
+                          <span className="text-sm font-medium">GitHub Configuration</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
+          {/* Help and Support Group */}
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel
+                asChild
+                className="text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer group-data-[collapsible=icon]:!opacity-100 group-data-[collapsible=icon]:!mt-0"
+              >
+                <CollapsibleTrigger className="flex w-full items-center font-semibold group-data-[collapsible=icon]:justify-center">
+                  <LifeBuoy className="h-4 w-4" aria-hidden />
+                  <span className="ml-2 group-data-[collapsible=icon]:hidden">Help & Support</span>
+                  <ChevronRight className="ml-auto h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" aria-hidden />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent className="group-data-[collapsible=icon]:hidden">
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild tooltip="Discord Community">
+                        <a 
+                          href="https://discord.com/channels/1131597983058755675/1169968780953260106" 
+                          target="_blank" 
+                          rel="noopener noreferrer" 
+                          className="flex w-full items-center rounded-md px-4 py-2 group-data-[collapsible=icon]:justify-center"
+                        >
+                          <span className="text-sm font-medium">Discord Community</span>
+                        </a>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild tooltip="Report an Issue">
+                         <a 
+                          href="https://github.com/unoplat/unoplat-code-confluence/issues" 
+                          target="_blank" 
+                          rel="noopener noreferrer" 
+                          className="flex w-full items-center rounded-md px-4 py-2 group-data-[collapsible=icon]:justify-center"
+                        >
+                          <span className="text-sm font-medium">Report an Issue</span>
+                        </a>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
         </div>
       </SidebarContent>
-
       {showUserInfo && (
         <SidebarFooter className="px-2 py-3">
           <NavUser user={user} />
         </SidebarFooter>
       )}
-      
       {/* Add the sidebar rail for dragging/resizing */}
       <SidebarRail />
     </Sidebar>

--- a/unoplat-code-confluence-frontend/src/components/ui/collapsible.tsx
+++ b/unoplat-code-confluence-frontend/src/components/ui/collapsible.tsx
@@ -1,0 +1,9 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/unoplat-code-confluence-frontend/src/routes/_app.onboarding.tsx
+++ b/unoplat-code-confluence-frontend/src/routes/_app.onboarding.tsx
@@ -15,5 +15,5 @@ const codeConfluenceSearchSchema = z.object({
 export const Route = createFileRoute('/_app/onboarding')({
   component: OnboardingPage,
   validateSearch: zodValidator(codeConfluenceSearchSchema),
-  beforeLoad: () => ({ getTitle: () => 'Onboarding' }),
+  beforeLoad: () => ({ getTitle: () => 'Github Onboarding' }),
 });

--- a/unoplat-code-confluence-frontend/src/routes/_app.settings.tsx
+++ b/unoplat-code-confluence-frontend/src/routes/_app.settings.tsx
@@ -2,6 +2,6 @@ import { createFileRoute } from '@tanstack/react-router';
 import SettingsPage from '../pages/SettingsPage';
 
 export const Route = createFileRoute('/_app/settings')({
-  beforeLoad: () => ({ getTitle: () => 'Settings' }),
+  beforeLoad: () => ({ getTitle: () => 'Github Configuration' }),
   component: SettingsPage,
 }); 

--- a/unoplat-code-confluence-frontend/yarn.lock
+++ b/unoplat-code-confluence-frontend/yarn.lock
@@ -830,6 +830,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-collapsible@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-collapsible@npm:1.1.7"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.2"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-presence": "npm:1.1.3"
+    "@radix-ui/react-primitive": "npm:2.1.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/5b0e55a76f368440cd5a6d11537500f93fb4466c536cee7b1d48130c9bc4337c3441fb5d9eac741f7a3cef5d16279c6beb3f050be1db8e8bfa519a30a1dac113
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-collection@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-collection@npm:1.1.3"
@@ -1428,6 +1454,37 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/2f5c532dba7bc13bd0b82b3473ee350ad2020c17898d3ea29371d4b8cc8c8fb1c6139b20b9590e9317d4f3bf312a706985e69310f5f8adfd47a94fef1ee39e72
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
+  dependencies:
+    "@radix-ui/react-use-effect-event": "npm:0.0.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/f55c4b06e895293aed4b44c9ef26fb24432539f5346fcd6519c7745800535b571058685314e83486a45bf61dc83887e24826490d3068acc317fb0a9010516e63
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/e84ff72a3e76c5ae9c94941028bb4b6472f17d4104481b9eab773deab3da640ecea035e54da9d6f4df8d84c18ef6913baf92b7511bee06930dc58bd0c0add417
   languageName: node
   linkType: hard
 
@@ -5463,6 +5520,7 @@ __metadata:
     "@radix-ui/react-alert-dialog": "npm:^1.1.6"
     "@radix-ui/react-avatar": "npm:^1.1.6"
     "@radix-ui/react-checkbox": "npm:^1.1.4"
+    "@radix-ui/react-collapsible": "npm:^1.1.7"
     "@radix-ui/react-dialog": "npm:^1.1.7"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.6"
     "@radix-ui/react-label": "npm:^2.1.2"


### PR DESCRIPTION
Introduce collapsible sections in the sidebar to improve navigation
and organization. Group related menu items under "Workspace Setup" and
"Settings" with toggleable visibility using Radix UI's Collapsible
component. This enhances the user experience by reducing clutter and
allowing users to focus on relevant options. Also update dependencies
to include @radix-ui/react-collapsible for this functionality.