### PR TITLE
fix(app): skip global token popup on onboarding page

### DIFF
--- a/unoplat-code-confluence-frontend/src/routes/_app.tsx
+++ b/unoplat-code-confluence-frontend/src/routes/_app.tsx
@@ -21,12 +21,17 @@ function AppComponent(): React.ReactElement {
 
   // Show token popup if no token is present
   useEffect(() => {
+    // Skip the global popup when on the onboarding page (handled locally in OnboardingPage)
+    if (routerState.location.pathname === '/onboarding') {
+      setShowTokenPopup(false);
+      return;
+    }
     if (tokenStatus && !tokenStatus.status && tokenStatus.errorCode !== 503) {
       setShowTokenPopup(true);
     } else {
       setShowTokenPopup(false);
     }
-  }, [tokenStatus]);
+  }, [tokenStatus, routerState.location.pathname]);
 
   // Handle root path navigation
   useEffect(() => {


### PR DESCRIPTION
Prevent the global token popup from showing when the user is on the
/onboarding route, as this is handled locally within the OnboardingPage.
Add router pathname to the effect dependencies to ensure correct popup
behavior on route changes. This improves user experience by avoiding
redundant popups during onboarding.