### PR TITLE
fix(app): remove GitHubTokenPopup and update tooltip dependency

### DIFF
--- a/unoplat-code-confluence-frontend/package.json
+++ b/unoplat-code-confluence-frontend/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-switch": "^1.2.2",
     "@radix-ui/react-toast": "^1.2.6",
-    "@radix-ui/react-tooltip": "^1.2.0",
+    "@radix-ui/react-tooltip": "^1.2.4",
     "@tailwindcss/postcss": "^4.0.17",
     "@tanstack/react-form": "^1.1.2",
     "@tanstack/react-query": "^5.69.0",

--- a/unoplat-code-confluence-frontend/src/routes/_app.tsx
+++ b/unoplat-code-confluence-frontend/src/routes/_app.tsx
@@ -1,37 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { createFileRoute, Outlet, useNavigate, useRouterState } from '@tanstack/react-router';
-import GitHubTokenPopup from '../components/custom/GitHubTokenPopup';
-import { useAuthStore } from '../stores/useAuthStore';
-import { useAuthData } from '@/hooks/use-auth-data';
 
 export const Route = createFileRoute('/_app')({
   component: AppComponent,
 });
 
 function AppComponent(): React.ReactElement {
-  const [showTokenPopup, setShowTokenPopup] = useState<boolean>(false);
   const navigate = useNavigate();
   const routerState = useRouterState();
-  
-  // Use useAuthData hook which manages both querying and updating the Zustand store
-  const { tokenQuery } = useAuthData();
-  
-  // Get tokenStatus from the store (which is updated by useAuthData)
-  const tokenStatus = useAuthStore(state => state.tokenStatus);
-
-  // Show token popup if no token is present
-  useEffect(() => {
-    // Skip the global popup when on the onboarding page (handled locally in OnboardingPage)
-    if (routerState.location.pathname === '/onboarding') {
-      setShowTokenPopup(false);
-      return;
-    }
-    if (tokenStatus && !tokenStatus.status && tokenStatus.errorCode !== 503) {
-      setShowTokenPopup(true);
-    } else {
-      setShowTokenPopup(false);
-    }
-  }, [tokenStatus, routerState.location.pathname]);
 
   // Handle root path navigation
   useEffect(() => {
@@ -39,17 +15,9 @@ function AppComponent(): React.ReactElement {
       navigate({ to: '/onboarding' });
     }
   }, [navigate, routerState.location.pathname]);
-  
+
   return (
     <>
-      <GitHubTokenPopup 
-        open={showTokenPopup} 
-        onClose={() => {
-          setShowTokenPopup(false);
-          // Refresh token status query when popup is closed
-          tokenQuery.refetch();
-        }} 
-      />
       <Outlet />
     </>
   );

--- a/unoplat-code-confluence-frontend/yarn.lock
+++ b/unoplat-code-confluence-frontend/yarn.lock
@@ -1345,6 +1345,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-presence@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-presence@npm:1.1.4"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/8202647139d6f5097b0abcc43dfba471c00b69da95ca336afe3ea23a165e05ca21992f40fc801760fe442f3e064e54e2f2cbcb9ad758c4b07ef6c69a5b6777bd
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-primitive@npm:2.0.3, @radix-ui/react-primitive@npm:^2.0.2":
   version: 2.0.3
   resolution: "@radix-ui/react-primitive@npm:2.0.3"
@@ -1567,22 +1587,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tooltip@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@radix-ui/react-tooltip@npm:1.2.0"
+"@radix-ui/react-tooltip@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "@radix-ui/react-tooltip@npm:1.2.4"
   dependencies:
     "@radix-ui/primitive": "npm:1.1.2"
     "@radix-ui/react-compose-refs": "npm:1.1.2"
     "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.6"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.7"
     "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.3"
-    "@radix-ui/react-portal": "npm:1.1.5"
-    "@radix-ui/react-presence": "npm:1.1.3"
-    "@radix-ui/react-primitive": "npm:2.0.3"
+    "@radix-ui/react-popper": "npm:1.2.4"
+    "@radix-ui/react-portal": "npm:1.1.6"
+    "@radix-ui/react-presence": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.0"
     "@radix-ui/react-slot": "npm:1.2.0"
-    "@radix-ui/react-use-controllable-state": "npm:1.1.1"
-    "@radix-ui/react-visually-hidden": "npm:1.1.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    "@radix-ui/react-visually-hidden": "npm:1.2.0"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -1593,7 +1613,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10c0/c497a855354afba9e8ffa386eebdb741c57788ba0a44c8f2360266d26a7e32ebad444db1e4364c02d63aa694be11681f378443bbd4e7a6d0704e7410368dccf6
+  checksum: 10c0/da07e538f26a309edac954bf6bd04835209e96ec79c6812cebd656f94513b4b6667501a610aeb85f3858310be2d6c4acb3a279857bafd2578be36f30962ebee6
   languageName: node
   linkType: hard
 
@@ -1758,6 +1778,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/1c6aa9d2eaff07ec3b86ef304619a8c9c8dc9dfe6e60024656072dbd288bf3a2b15a55657a7f1b4daac704b37d34ab915cb97666f062df337f586b99ba9d82ea
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-visually-hidden@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@radix-ui/react-visually-hidden@npm:1.2.0"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/58d9dc7b39078b3da609e51d0cb0f5fa80b547ba94f8794d20616e34d5c1724b8908d6cc253797f78983eed7e29d04a092e4810161658c0d890389743cdd34c1
   languageName: node
   linkType: hard
 
@@ -5716,7 +5755,7 @@ __metadata:
     "@radix-ui/react-slot": "npm:^1.2.0"
     "@radix-ui/react-switch": "npm:^1.2.2"
     "@radix-ui/react-toast": "npm:^1.2.6"
-    "@radix-ui/react-tooltip": "npm:^1.2.0"
+    "@radix-ui/react-tooltip": "npm:^1.2.4"
     "@tailwindcss/postcss": "npm:^4.0.17"
     "@tanstack/react-form": "npm:^1.1.2"
     "@tanstack/react-query": "npm:^5.69.0"


### PR DESCRIPTION
Remove the GitHubTokenPopup component and related state management from the
AppComponent to simplify the authentication UI flow. The token popup logic
is no longer needed globally, improving code clarity and reducing complexity.

Also update @radix-ui/react-tooltip from 1.2.0 to 1.2.4 to incorporate the
latest fixes and improvements in the tooltip component.