### PR TITLE
fix(logging): set default log level to INFO from DEBUG

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/logging/log_config.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/logging/log_config.py
@@ -13,7 +13,7 @@ class LogConfig:
     def make_logger_config(log_path: str = "logs") -> Dict[str, Any]:
         """Return logger configuration"""
         # Use environment variable LOG_LEVEL to control logging level, default is "INFO"
-        log_level: str = os.getenv("LOG_LEVEL", "DEBUG")
+        log_level: str = os.getenv("LOG_LEVEL", "INFO")
         return {
             "handlers": [
                 {


### PR DESCRIPTION
Change the default logging level from DEBUG to INFO by reading the
LOG_LEVEL environment variable. This reduces verbosity in production
environments while still allowing override via environment settings.