### PR TITLE
feat(logging): standardize and enhance logging details

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/Taskfile.yml
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/Taskfile.yml
@@ -63,7 +63,7 @@ tasks:
     deps: [sync]
     dir: src/code_confluence_flow_bridge
     env:
-      SCANNER_JAR_PATH: "{{.HOME}}/.unoplat/repositories/assets/scanner_cli-2.2.8-all.jar"
+      SCANNER_JAR_PATH: "{{.HOME}}/.unoplat/repositories/assets/scanner_cli-2.3.0-all.jar"
       DB_HOST: "localhost"
       DB_PORT: "5432"
       DB_USER: "postgres"

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/logging/log_config.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/logging/log_config.py
@@ -13,7 +13,7 @@ class LogConfig:
     def make_logger_config(log_path: str = "logs") -> Dict[str, Any]:
         """Return logger configuration"""
         # Use environment variable LOG_LEVEL to control logging level, default is "INFO"
-        log_level: str = os.getenv("LOG_LEVEL", "INFO")
+        log_level: str = os.getenv("LOG_LEVEL", "DEBUG")
         return {
             "handlers": [
                 {

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/main.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/main.py
@@ -1,4 +1,3 @@
-import httpx
 from src.code_confluence_flow_bridge.logging.log_config import setup_logging
 from src.code_confluence_flow_bridge.models.configuration.settings import EnvironmentSettings
 
@@ -41,6 +40,7 @@ from fastapi.middleware.cors import CORSMiddleware
 # Add imports for gql
 from gql import Client as GQLClient, gql
 from gql.transport.aiohttp import AIOHTTPTransport
+import httpx
 from loguru import logger
 from sqlmodel import Session, select
 from temporalio.client import Client, WorkflowHandle

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/processor/archguard/arc_guard_handler.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/processor/archguard/arc_guard_handler.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 # Third Party
 from loguru import logger
-from temporalio import activity
 
 
 class ArchGuardHandler:
@@ -24,7 +23,13 @@ class ArchGuardHandler:
         self.output_path = output_path
         self.codebase_name = codebase_name
         self.extension = extension
-        
+        # Create a contextualized logger for this instance
+        self.log = logger.bind(
+            codebase=codebase_name,
+            language=language,
+            jar_path=jar_path
+        )
+        self.log.debug("Initialized ArchGuardHandler with output path: {}", self.output_path)
 
     def run_scan(self) -> str:
         """
@@ -34,27 +39,21 @@ class ArchGuardHandler:
             str: Path to the generated JSON file
         """
         # Expand the jar path if it contains tilde
-        logger.debug(f"jar path:{self.jar_path}")
         expanded_jar_path: str = os.path.expanduser(self.jar_path)
-        logger.debug(f"expanded_jar_path:{expanded_jar_path}")
+        self.log.debug("Expanded jar path: {}", expanded_jar_path)
         
-        activity.logger.info(
-            "Starting ArchGuard scan",
-            extra={
-                "language": self.language,
-                "codebase": self.codebase_name
-            }
-        )
+        self.log.info("Starting ArchGuard scan")
 
         # Store current directory before changing it
         original_dir: str = os.getcwd()
         
         try:
             # Change to output directory before running command
-            logger.debug("Current working directory: {}", os.getcwd())
+            self.log.debug("Changing working directory from {} to {}", os.getcwd(), self.output_path)
             os.chdir(self.output_path)
-            logger.debug(f"Changed working directory to: {self.output_path}")
 
+            self.log.debug("Using output path for ArchGuard command: {}", os.path.abspath(self.output_path))
+            
             command = [
                 "java", "-jar", expanded_jar_path,
                 "--with-function-code",
@@ -64,10 +63,7 @@ class ArchGuardHandler:
                 f"--output-dir={self.output_path}",
                 f"--depth=30"
             ]
-            logger.info(
-                "Executing command",
-                extra={"command": ' '.join(command)}
-            )
+            self.log.info("Executing command: {}", ' '.join(command))
             
             process = subprocess.Popen(
                 command, 
@@ -78,19 +74,12 @@ class ArchGuardHandler:
             )
             
             if process.stdout is None:
-                logger.error("Failed to open subprocess stdout")
+                self.log.error("Failed to open subprocess stdout")
                 raise RuntimeError("Failed to open subprocess stdout")
                 
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-                if output:
-                    logger.debug(output.strip())
-                    
             _stdout, stderr = process.communicate()
             if process.returncode == 0:
-                logger.info("ArchGuard scan completed successfully")
+                self.log.info("ArchGuard scan completed successfully")
                 
                 # Use absolute path for output file
                 output_file: str = os.path.join(self.output_path, "0_codes.json")
@@ -99,35 +88,15 @@ class ArchGuardHandler:
                 
                 try:
                     os.rename(output_file, new_file)
-                    activity.logger.debug(
-                        "Renamed output file",
-                        extra={
-                            "old_path": output_file,
-                            "new_path": new_file
-                        }
-                    )
+                    self.log.debug("Renamed output file from {} to {}", output_file, new_file)
                     return new_file
                 except OSError as e:
-                    activity.logger.error(
-                        "Failed to rename output file",
-                        extra={
-                            "error": str(e),
-                            "old_path": output_file,
-                            "new_path": new_file
-                        }
-                    )
+                    self.log.error("Failed to rename output file from {} to {}: {}", output_file, new_file, str(e))
                     raise
             else:
-                activity.logger.error(
-                    "Error in ArchGuard scanning",
-                    extra={
-                        "error": stderr,
-                        "return_code": process.returncode
-                    }
-                )
+                self.log.error("Error in ArchGuard scanning: {} (return code: {})", stderr, process.returncode)
                 raise RuntimeError(f"ArchGuard scan failed: {command} with error {stderr}")
         finally:
             # Always restore original directory
             os.chdir(original_dir)
-            activity.logger.info(f"Restored working directory to: {original_dir}")
-
+            self.log.info("Restored working directory: {}", original_dir)

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/processor/package_metadata_activity/package_manager_metadata_activity.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/processor/package_metadata_activity/package_manager_metadata_activity.py
@@ -29,23 +29,23 @@ class PackageMetadataActivity:
         """
         try:
             info = activity.info()
-            logger.info(
-                "Processing package metadata",
-                extra={
-                    "temporal_workflow_id": info.workflow_id,
-                    "temporal_activity_id": info.activity_id,
-                    "codebase_path": local_path,
-                    "programming_language": programming_language_metadata.language.value,
-                    "language_version": programming_language_metadata.language_version,
-                    "package_manager": programming_language_metadata.package_manager.value,
-                },
+            logger.debug(
+                "Processing package metadata | workflow_id={} | activity_id={} | codebase_path={} | programming_language={} | language_version={} | package_manager={}",
+                info.workflow_id, info.activity_id, local_path, programming_language_metadata.language.value, programming_language_metadata.language_version, programming_language_metadata.package_manager.value
             )
 
             package_metadata = self.package_manager_parser.parse_package_metadata(local_workspace_path=local_path, programming_language_metadata=programming_language_metadata)
 
-            logger.info("Successfully processed package metadata", extra={"temporal_workflow_id": info.workflow_id, "temporal_activity_id": info.activity_id, "codebase_path": local_path, "status": "success"})
+            logger.debug(
+                "Successfully processed package metadata | workflow_id={} | activity_id={} | codebase_path={} | status=success",
+                info.workflow_id, info.activity_id, local_path
+            )
             return package_metadata
 
         except Exception as e:
-            logger.error("Failed to process package metadata", extra={"temporal_workflow_id": activity.info().workflow_id, "temporal_activity_id": activity.info().activity_id, "error_type": type(e).__name__, "error_details": str(e), "codebase_path": local_path, "status": "error"})
+            info = activity.info()
+            logger.debug(
+                "Failed to process package metadata | workflow_id={} | activity_id={} | codebase_path={} | error_type={} | error_details={} | status=error",
+                info.workflow_id, info.activity_id, local_path, type(e).__name__, str(e)
+            )
             raise ApplicationError(message=f"Failed to process package metadata for {local_path}", type="PACKAGE_METADATA_ERROR")

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/processor/package_metadata_activity/package_manager_metadata_ingestion.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/processor/package_metadata_activity/package_manager_metadata_ingestion.py
@@ -3,6 +3,7 @@ from src.code_confluence_flow_bridge.processor.db.graph_db.code_confluence_graph
 
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
+from loguru import logger
 
 
 class PackageManagerMetadataIngestion:
@@ -12,7 +13,7 @@ class PackageManagerMetadataIngestion:
 
     def __init__(self, code_confluence_graph_ingestion: CodeConfluenceGraphIngestion):
         self.code_confluence_graph_ingestion = code_confluence_graph_ingestion
-        activity.logger.info("Initialized PackageManagerMetadataIngestion")
+        logger.debug("Initialized PackageManagerMetadataIngestion")
 
     @activity.defn
     async def insert_package_manager_metadata(self, codebase_qualified_name: str, package_manager_metadata: UnoplatPackageManagerMetadata) -> None:
@@ -25,15 +26,22 @@ class PackageManagerMetadataIngestion:
         """
         try:
             info = activity.info()
-            activity.logger.info(
-                "Starting package manager metadata ingestion",
-                extra={"temporal_workflow_id": info.workflow_id, "temporal_activity_id": info.activity_id, "codebase_name": codebase_qualified_name, "programming_language": package_manager_metadata.programming_language, "package_manager": package_manager_metadata.package_manager},
+            logger.debug(
+                "Starting package manager metadata ingestion | workflow_id={} | activity_id={} | codebase_name={} | programming_language={} | package_manager={}",
+                info.workflow_id, info.activity_id, codebase_qualified_name, package_manager_metadata.programming_language, package_manager_metadata.package_manager
             )
 
             await self.code_confluence_graph_ingestion.insert_code_confluence_codebase_package_manager_metadata(codebase_qualified_name=codebase_qualified_name, package_manager_metadata=package_manager_metadata)
 
-            activity.logger.info("Successfully ingested package manager metadata", extra={"temporal_workflow_id": info.workflow_id, "temporal_activity_id": info.activity_id, "codebase_name": codebase_qualified_name, "status": "success"})
+            logger.debug(
+                "Successfully ingested package manager metadata | workflow_id={} | activity_id={} | codebase_name={} | status=success",
+                info.workflow_id, info.activity_id, codebase_qualified_name
+            )
 
         except Exception as e:
-            activity.logger.error("Failed to ingest package manager metadata", extra={"temporal_workflow_id": activity.info().workflow_id, "temporal_activity_id": activity.info().activity_id, "error_type": type(e).__name__, "error_details": str(e), "codebase_name": codebase_qualified_name, "status": "error"})
+            info = activity.info()
+            logger.debug(
+                "Failed to ingest package manager metadata | workflow_id={} | activity_id={} | codebase_name={} | error_type={} | error_details={} | status=error",
+                info.workflow_id, info.activity_id, codebase_qualified_name, type(e).__name__, str(e)
+            )
             raise ApplicationError(message=f"Failed to ingest package manager metadata for {codebase_qualified_name}", type="PACKAGE_METADATA_INGESTION_ERROR")

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.30.0"
+version = "0.31.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
Change package metadata activity logs from info to debug level and
consolidate log messages into formatted strings for better readability.
Include detailed context such as workflow and activity IDs, codebase
path, programming language, and package manager in logs.
squashed nasty bug due to archguard handler process poll
In repo workflow, unify logger usage by assigning workflow.logger to a
local variable and add debug logs for child workflow arguments to
improve traceability during execution.