### PR TITLE
fix(env): update default backend service URLs

### DIFF
--- a/unoplat-code-confluence-frontend/src/lib/env.ts
+++ b/unoplat-code-confluence-frontend/src/lib/env.ts
@@ -23,7 +23,7 @@ export const env: Env = {
   /**
    * API Base URL for backend requests
    */
-  apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
-  workflowOrchestratorUrl: import.meta.env.VITE_WORKFLOW_ORCHESTRATOR_URL || 'http://temporal-ui.code-confluence-flow-bridge.orb.local/namespaces/default/workflows',
-  knowledgeGraphUrl: import.meta.env.VITE_KNOWLEDGE_GRAPH_URL || 'http://neo4j.code-confluence-flow-bridge.orb.local/browser/',
+  apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://code-confluence-flow-bridge:8000',
+  workflowOrchestratorUrl: import.meta.env.VITE_WORKFLOW_ORCHESTRATOR_URL || 'http://temporal-ui:8080',
+  knowledgeGraphUrl: import.meta.env.VITE_KNOWLEDGE_GRAPH_URL || 'http://neo4j:7687',
 }; 


### PR DESCRIPTION
Change default API base URL, workflow orchestrator, and knowledge
graph URLs to use internal service hostnames instead of localhost or
external addresses. This ensures the frontend connects correctly to
backend services in the deployment environment.