### PR TITLE
fix(env): update default API URLs to localhost

### DIFF
--- a/unoplat-code-confluence-frontend/src/lib/env.ts
+++ b/unoplat-code-confluence-frontend/src/lib/env.ts
@@ -23,7 +23,7 @@ export const env: Env = {
   /**
    * API Base URL for backend requests
    */
-  apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://code-confluence-flow-bridge:8000',
-  workflowOrchestratorUrl: import.meta.env.VITE_WORKFLOW_ORCHESTRATOR_URL || 'http://temporal-ui:8080',
-  knowledgeGraphUrl: import.meta.env.VITE_KNOWLEDGE_GRAPH_URL || 'http://neo4j:7687',
+  apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
+  workflowOrchestratorUrl: import.meta.env.VITE_WORKFLOW_ORCHESTRATOR_URL || 'http://localhost:8080',
+  knowledgeGraphUrl: import.meta.env.VITE_KNOWLEDGE_GRAPH_URL || 'http://localhost:7687',
 }; 


### PR DESCRIPTION
Change default backend service URLs in env.ts to point to localhost
instead of container hostnames. This simplifies local development and
testing by ensuring the frontend connects to services running on the
local machine by default.