### PR TITLE
fix: update frontend image and flow-bridge version

### DIFF
--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -152,11 +152,11 @@ services:
     stdin_open: true
     tty: true
   unoplat-code-confluence-frontend:
-    image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.19.0
+    image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.19.2
     environment:
       - VITE_API_BASE_URL=http://code-confluence-flow-bridge:8000
       - VITE_WORKFLOW_ORCHESTRATOR_URL=http://temporal-ui:8080
-      - VITE_KNOWLEDGE_GRAPH_URL=http://neo4j:7474
+      - VITE_KNOWLEDGE_GRAPH_URL=http://neo4j:7687
     ports:
       - "3000:80"
     networks:

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.31.1"
+version = "0.32.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
Update unoplat-code-confluence-frontend image to 1.19.2 to include
latest fixes and improvements. Change VITE_KNOWLEDGE_GRAPH_URL port
from 7474 to 7687 to match the correct Neo4j Bolt protocol port.

Bump code-confluence-flow-bridge version from 0.31.1 to 0.32.0 to
reflect recent changes and ensure compatibility with updated services.