### PR TITLE
fix(env): update default knowledgeGraphUrl port to 7474

### DIFF
--- a/unoplat-code-confluence-frontend/src/lib/env.ts
+++ b/unoplat-code-confluence-frontend/src/lib/env.ts
@@ -25,5 +25,5 @@ export const env: Env = {
    */
   apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
   workflowOrchestratorUrl: import.meta.env.VITE_WORKFLOW_ORCHESTRATOR_URL || 'http://localhost:8080',
-  knowledgeGraphUrl: import.meta.env.VITE_KNOWLEDGE_GRAPH_URL || 'http://localhost:7687',
+  knowledgeGraphUrl: import.meta.env.VITE_KNOWLEDGE_GRAPH_URL || 'http://localhost:7474',
 }; 


### PR DESCRIPTION
Change the default port for knowledgeGraphUrl from 7687 to 7474 to
align with the standard HTTP port used by the knowledge graph service.
This ensures correct connectivity when environment variables are not set.