### PR TITLE
feat: export CodeConfluenceFile in package __init__.py

### DIFF
--- a/unoplat-code-confluence-commons/unoplat_code_confluence_commons/__init__.py
+++ b/unoplat-code-confluence-commons/unoplat_code_confluence_commons/__init__.py
@@ -13,7 +13,8 @@ from .graph_models import (
     CodeConfluencePackageManagerMetadata,
     BaseNode,
     ContainsRelationship,
-    AnnotatedRelationship
+    AnnotatedRelationship,
+    CodeConfluenceFile
 )
 
 __all__ = [
@@ -26,5 +27,6 @@ __all__ = [
     'CodeConfluencePackageManagerMetadata',
     'BaseNode',
     'ContainsRelationship',
-    'AnnotatedRelationship'
+    'AnnotatedRelationship',
+    'CodeConfluenceFile'
 ]


### PR DESCRIPTION
Add CodeConfluenceFile to the list of exported symbols in the
unoplat_code_confluence_commons package. This change enables users
to import and use CodeConfluenceFile directly from the package,
improving accessibility and consistency with other exported classes.