### PR TITLE
refactor: update CodeConfluenceFile to use AsyncStructuredNode

### DIFF
--- a/unoplat-code-confluence-commons/tests/test_graph_models.py
+++ b/unoplat-code-confluence-commons/tests/test_graph_models.py
@@ -112,7 +112,6 @@ async def test_complete_hierarchy() -> None:
     
     # Create file
     file: CodeConfluenceFile = await CodeConfluenceFile(
-        qualified_name="org/repo/main/package/path.py",
         file_path="/test/path.py",
         content="# Test file content",
         checksum="abcdef123456"
@@ -177,7 +176,6 @@ async def test_complete_hierarchy() -> None:
     class_file = await found_class.file.all()
     assert len(class_file) == 1
     assert class_file[0].file_path == "/test/path.py"
-    assert class_file[0].qualified_name == found_file.qualified_name
     
     # Verify function in class
     class_functions: List[CodeConfluenceInternalFunction] = await found_class.functions.all()

--- a/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
+++ b/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
@@ -1,10 +1,10 @@
 # new imports (top of the file, after existing neomodel import list)
-from neomodel import StringProperty, AsyncRelationshipTo, AsyncRelationship, AsyncOne, AsyncZeroOrMore
+from neomodel import AsyncStructuredNode, StringProperty, AsyncRelationshipTo, AsyncRelationship, AsyncOne, AsyncZeroOrMore
 
 from unoplat_code_confluence_commons.graph_models.base_models import BaseNode, ContainsRelationship
 
 # ⬇️  insert just above class `CodeConfluencePackage`
-class CodeConfluenceFile(BaseNode):
+class CodeConfluenceFile(AsyncStructuredNode):
     """
     Graph node representing a single source file.
 


### PR DESCRIPTION
Change CodeConfluenceFile to inherit from AsyncStructuredNode instead
of BaseNode to align with async graph model conventions. Remove
redundant qualified_name attribute from test setup and assertions to
simplify test cases and focus on essential properties. These changes
improve async compatibility and test clarity.