### PR TITLE
chore(deps): update unoplat-code-confluence-commons to v0.14.1

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/.windsurf/rules/think-tool-usage.md
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/.windsurf/rules/think-tool-usage.md
@@ -1,0 +1,22 @@
+---
+trigger: always_on
+---
+
+After any context change (viewing new files, running commands, or receiving tool outputs), use the "mcp_think" tool to organize your reasoning before responding.
+
+Specifically, always use the think tool when:
+- After examining file contents or project structure
+- After running terminal commands or analyzing their outputs
+- After receiving search results or API responses
+- Before making code suggestions or explaining complex concepts
+- When transitioning between different parts of a task
+
+When using the think tool:
+- List the specific rules or constraints that apply to the current task
+- Check if all required information is collected
+- Verify that your planned approach is correct
+- Break down complex problems into clearly defined steps
+- Analyze outputs from other tools thoroughly
+- Plan multi-step approaches before executing them
+
+The think tool has been proven to improve performance by up to 54% on complex tasks, especially when working with multiple tools or following detailed policies.

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/Taskfile.yml
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/Taskfile.yml
@@ -51,7 +51,21 @@ tasks:
     dir: .
     cmds:
       - uv sync
-  
+
+  update-package:
+    desc: Update a specific package to the latest allowed version using uv (usage - task update-package PACKAGE=package_name)
+    vars:
+      PACKAGE: '{{.PACKAGE}}'
+    requires:
+      vars: [PACKAGE]
+    cmds:
+      - uv lock --upgrade-package {{.PACKAGE}}
+
+  update-all-packages:
+    desc: Update all packages to the latest allowed versions using uv
+    cmds:
+      - uv lock --upgrade
+
   run-client:
     desc: run client to submit request to code confluence flow code-confluence-flow-bridge
     dir: ../../unoplat-code-confluence-cli


### PR DESCRIPTION
docs(rules): add think-tool-usage rule for reasoning workflow

Introduce a new Windsurf rule that mandates using the "mcp_think" tool
after context changes to structure reasoning and improve task
performance. This helps ensure thorough analysis and planning before
responding or making suggestions.