### PR TITLE
fix: remove unused React import from ModeToggle component

### DIFF
--- a/unoplat-code-confluence-frontend/src/components/custom/ModeToggle.tsx
+++ b/unoplat-code-confluence-frontend/src/components/custom/ModeToggle.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { Moon, Sun } from "lucide-react"
 
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
Eliminate the unnecessary import of React in ModeToggle.tsx to clean
up the code and reduce potential confusion, as React is not directly
used in the file. This improves code clarity and follows modern React
practices.