### PR TITLE
Fix loading state jitter in SubmittedJobsDataTable

### DIFF
--- a/unoplat-code-confluence-frontend/src/components/custom/SubmittedJobsDataTable.tsx
+++ b/unoplat-code-confluence-frontend/src/components/custom/SubmittedJobsDataTable.tsx
@@ -4,7 +4,7 @@
 // Import necessary React hooks.
 import { useState, useEffect, useMemo } from "react";
 // Import useQuery from TanStack Query.
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import React from "react";
 
 // Import the Dice UI DataTable component which is built on TanStack Table.
@@ -60,11 +60,13 @@ export function SubmittedJobsDataTable(): React.ReactElement {
   const {
     data: jobs = [],
     isFetching,
+    isPlaceholderData,
   } = useQuery({
     queryKey: ['parentWorkflowJobs'],
     queryFn: fetchParentWorkflowJobs,
     staleTime: 1000 * 60 * 1, // 1 minute
     refetchInterval: 1000 * 5, // Refetch every 5 seconds for active jobs
+    placeholderData: keepPreviousData,
   });
   
   
@@ -123,7 +125,7 @@ export function SubmittedJobsDataTable(): React.ReactElement {
       <DataTable
         table={table}
         actionBar={null}
-        isLoading={isFetching}
+        isLoading={isFetching && !isPlaceholderData}
       >
         <DataTableToolbar table={table} />
       </DataTable>


### PR DESCRIPTION
### **User description**
## Summary
- keep previous job data during refetches
- only show skeletons when there's no existing data

## Testing
- `yarn lint` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_b_6840436053f48323942b6819c5fbc0b3


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Retain previous job data during table refetches
  - Prevents UI jitter by keeping old data visible
  - Only shows loading skeletons if no data exists

- Adjust loading state logic to use placeholder data


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubmittedJobsDataTable.tsx</strong><dd><code>Preserve table data and refine loading state handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-frontend/src/components/custom/SubmittedJobsDataTable.tsx

<li>Use <code>keepPreviousData</code> to retain old data during refetches<br> <li> Add <code>isPlaceholderData</code> to loading state logic<br> <li> Only show loading skeletons when no previous data exists<br> <li> Update <code>isLoading</code> prop to prevent unnecessary skeletons


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/578/files#diff-dca0d3abbfff9628da9346c1a739bf270d94a5ae3ad225dfc017df25776d8434">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>