### PR TITLE
fix: svgs for dark mode in docs

### DIFF
--- a/code-confluence/static/img/roadmap.svg
+++ b/code-confluence/static/img/roadmap.svg
@@ -6,11 +6,11 @@
     <style class="text-font-style fontImports" data-font-family="Shantell Sans">
         @import url('https://fonts.googleapis.com/css2?family=Shantell+Sans:wght@300..800&amp;display=block');
     </style>
-    <rect id="" x="0" y="0" width="565" height="866" style="fill: #ffffff;"></rect>
+    <rect id="" x="0" y="0" width="565" height="866" style="fill: transparent;"></rect>
     <g id="items" style="isolation: isolate">
         <g id="blend" style="mix-blend-mode: normal">
             <g id="g-root-tf_1qdtpye1j9flsd-fill" data-item-order="-482112" transform="translate(-9, -9)">
-                <g id="tf_1qdtpye1j9flsd-fill" stroke="none" fill="#ffffff">
+                <g id="tf_1qdtpye1j9flsd-fill" stroke="none" fill="transparent">
                     <g>
                         <path d="M 10 10L 568 10L 568 874L 10 874Z"></path>
                     </g>

--- a/code-confluence/static/img/vision.svg
+++ b/code-confluence/static/img/vision.svg
@@ -6,7 +6,7 @@
     <style class="text-font-style fontImports" data-font-family="Roboto">
         @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=block');
     </style>
-    <rect id="" x="0" y="0" width="1130" height="626" style="fill: #ffffff;"></rect>
+    <rect id="" x="0" y="0" width="1130" height="626" style="fill: transparent;"></rect>
     <g id="items" style="isolation: isolate">
         <g id="blend" style="mix-blend-mode: normal">
             <g id="g-root-tf_zk1ttz1k30dfr-fill" data-item-order="-703872" transform="translate(-9, -9)"></g>


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
• Fixed SVG images to properly display in dark mode within documentation
• Improved visual consistency across different theme modes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>