### PR TITLE
fix: docker compose executable

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -63,6 +63,12 @@ jobs:
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
 
+      - name: Install docker-compose v1 for testcontainers compatibility
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
       - name: Install Ruff
         run: curl -LsSf https://astral.sh/ruff/install.sh | sh
         

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -60,14 +60,27 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Set up Docker Compose
+      # 1) Always ensure the Compose v2 plugin is present
+      - name: Set up Docker Compose (v2)
         uses: docker/setup-compose-action@v1
+        # pin a version if you need repeatability:
+        # with:
+        #   version: '2.37.0'
 
-      - name: Install docker-compose v1 for testcontainers compatibility
+      # 2) Drop in a shim so legacy tools that expect `docker-compose`
+      #    still work (but use v2 under the hood)
+      - name: Provide docker-compose wrapper for compatibility
+        shell: bash
         run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          docker-compose --version
+          if ! command -v docker-compose >/dev/null; then
+            echo 'Creating docker-compose wrapper ➜ docker compose "$@"'
+            sudo install -d /usr/local/bin
+            printf '#!/usr/bin/env bash\nexec docker compose "$@"\n' | \
+              sudo tee /usr/local/bin/docker-compose >/dev/null
+            sudo chmod +x /usr/local/bin/docker-compose
+          fi
+          docker compose version
+          docker-compose version   # should output the same version
 
       - name: Install Ruff
         run: curl -LsSf https://astral.sh/ruff/install.sh | sh


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
• Install docker-compose v1 for testcontainers compatibility
• Add explicit docker-compose binary installation step
• Ensure docker-compose executable is available in CI pipeline


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_build.yaml</strong><dd><code>Install docker-compose v1 for testcontainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python_build.yaml

• Added step to install docker-compose v1.29.2 binary<br> • Downloads and <br>installs docker-compose executable to /usr/local/bin/<br> • Added version <br>verification command


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/599/files#diff-acffa834ca92a0147495c1b31c0f6fbe52107d39165a10e37fcd2f4357f4ad31">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>