### PR TITLE
fix: indexes

### DIFF
--- a/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
+++ b/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
@@ -14,17 +14,17 @@ class CodeConfluenceFile(AsyncStructuredNode):
     package  (PART_OF_PACKAGE)  -> CodeConfluencePackage
     """
     file_path = StringProperty(required=True, unique_index=True)
-    content   = StringProperty(fulltext_index=FulltextIndex(analyzer="english"))
+    content   = StringProperty(fulltext_index=FulltextIndex(analyzer="whitespace"))
     checksum  = StringProperty()
     structural_signature = JSONProperty()
     imports = ArrayProperty(
         StringProperty(),
         default=[],
-        fulltext_index=FulltextIndex(analyzer="english")
+        index=True
     )
     poi_labels = ArrayProperty(
         StringProperty(),
-        fulltext_index=FulltextIndex(analyzer="english")
+        index=True
     )
     package = AsyncRelationshipTo(
         '.code_confluence_package.CodeConfluencePackage',


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
• Updated fulltext index analyzer from "english" to "whitespace" for content field
• Changed imports and poi_labels from fulltext_index to simple index


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_confluence_file.py</strong><dd><code>Update indexing configuration for graph model properties</code>&nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py

• Changed content field fulltext index analyzer from "english" to <br>"whitespace"<br> • Replaced fulltext_index with simple index=True for <br>imports array property<br> • Replaced fulltext_index with simple <br>index=True for poi_labels array property


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/609/files#diff-4e16a46c5a8eee41277d0ad0f989187f3dbc09fcaac08d24b32a2a22617e98b9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>