### PR TITLE
fix: reverse edge from sub package to parent package

### DIFF
--- a/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_package.py
+++ b/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_package.py
@@ -22,13 +22,18 @@ class CodeConfluencePackage(BaseNode):
     name = StringProperty()
     
     
-    sub_packages = AsyncRelationship(
+    sub_packages = AsyncRelationshipTo(
         '.code_confluence_package.CodeConfluencePackage',
         'CONTAINS_PACKAGE',
         model=ContainsRelationship,
         cardinality=AsyncZeroOrMore
     )
-    
+    parent_package = AsyncRelationshipTo(
+        '.code_confluence_package.CodeConfluencePackage',
+        'PART_OF_PACKAGE',
+        model=ContainsRelationship,
+        cardinality=AsyncZeroOrMore,
+    )
     
     codebase = AsyncRelationshipTo(
         '.code_confluence_codebase.CodeConfluenceCodebase',


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix relationship type from `AsyncRelationship` to `AsyncRelationshipTo`

- Add reverse `parent_package` relationship for bidirectional package hierarchy


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_confluence_package.py</strong><dd><code>Fix package relationships and add parent reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_package.py

<li>Changed <code>sub_packages</code> from <code>AsyncRelationship</code> to <code>AsyncRelationshipTo</code><br> <li> Added new <code>parent_package</code> relationship with <code>PART_OF_PACKAGE</code> edge type<br> <li> Both relationships use <code>ContainsRelationship</code> model and <code>AsyncZeroOrMore</code> <br>cardinality


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/611/files#diff-3a9a580a9dcbd69f40996978b14381ffdc31f6bf55817a80e852d25c2aa4dbe0">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>