### PR TITLE
fix: remove content as we do have it available on host storage

### DIFF
--- a/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
+++ b/unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
@@ -14,7 +14,6 @@ class CodeConfluenceFile(AsyncStructuredNode):
     package  (PART_OF_PACKAGE)  -> CodeConfluencePackage
     """
     file_path = StringProperty(required=True, unique_index=True)
-    content   = StringProperty(fulltext_index=FulltextIndex(analyzer="whitespace"))
     checksum  = StringProperty()
     structural_signature = JSONProperty()
     imports = ArrayProperty(

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/code_confluence_parsing_models/unoplat_file.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/code_confluence_parsing_models/unoplat_file.py
@@ -11,7 +11,6 @@ class UnoplatFile(BaseModel):
     """Represents individual source code files."""
     
     file_path: str = Field(description="Absolute file path")
-    content: Optional[str] = Field(default=None, description="Optional file content")
     checksum: Optional[str] = Field(
         default=None, 
         description="Optional content checksum for change tracking"

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py
@@ -343,7 +343,6 @@ class GenericCodebaseParser:
             # Create UnoplatFile instance
             unoplat_file = UnoplatFile(
                 file_path=file_path,
-                content=content,
                 checksum=checksum,
                 structural_signature=signature,  # Store the actual object, not dict
                 imports=imports,
@@ -506,7 +505,6 @@ class GenericCodebaseParser:
                 # Create file node using helper method
                 file_dict = {
                     "file_path": unoplat_file.file_path,
-                    "content": unoplat_file.content,
                     "checksum": unoplat_file.checksum,
                     "structural_signature": unoplat_file.structural_signature.model_dump() if unoplat_file.structural_signature else {},
                     "imports": unoplat_file.imports,

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/processor/db/graph_db/test_code_confluence_graph_ingestion.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/processor/db/graph_db/test_code_confluence_graph_ingestion.py
@@ -233,7 +233,6 @@
 #         # Create a sample file with the node
 #         sample_file = UnoplatFile(
 #             file_path="/tmp/test-codebase/src/test_module/test_file.py",
-#             content="class TestClass:\n    pass",
 #             nodes=[sample_node]
 #         )
         


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove `content` property from `CodeConfluenceFile` graph model

- Optimize storage by relying on host storage for file content


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_confluence_file.py</strong><dd><code>Remove content property from graph model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/unoplat_code_confluence_commons/graph_models/code_confluence_file.py

<li>Removed <code>content</code> StringProperty with fulltext index from <br>CodeConfluenceFile class<br> <li> Simplified graph node model by eliminating redundant content storage


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/620/files#diff-4e16a46c5a8eee41277d0ad0f989187f3dbc09fcaac08d24b32a2a22617e98b9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>