### PR TITLE
feat: Update pytest command in GitHub Actions workflow

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -91,7 +91,7 @@ jobs:
           GITHUB_PAT_TOKEN: ${{ github.token }} 
         run: |
           uv sync --group test
-          uv run pytest --cov=src/code_confluence_flow_bridge --cov-report=html:coverage_reports --cov-report=xml:coverage.xml --cov-report=term-missing tests/ -v
+          uv run --group test pytest --cov=src/code_confluence_flow_bridge --cov-report=html:coverage_reports --cov-report=xml:coverage.xml --cov-report=term-missing tests/ -v
 
       - name: Set sanitized project name
         id: sanitize


### PR DESCRIPTION
Updates the pytest command in the GitHub Actions workflow to run
the tests with the `--group test` option. This ensures that the
tests are run within the appropriate test group, which is
necessary for the project's test suite setup.