### PR TITLE
fix(docker): use docker.io prefix for all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ Check out our [Quick Start Guide](https://docs.unoplat.io/).
 |----------------------------|:----:|:-----------:|
 | Repository Discovery       |  ✓   |             |
 | Auto Codebase Detection    |  ✓   |             |
-| Ingestion                  |  ✓   |             |
+| GitHub Ingestion           |  ✓   |             |
+| GitHub Manual Sync         |  ✓   |             |
+| Local Ingestion            |  ✓   |             |
+| Local Manual Sync          |  ✓   |             |
 | Chat With Codebase         |      |      ✓      |
 
 <!-- MAINTAINERS SECTION -->

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
       - OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m
-    image: opensearchproject/opensearch:2.14.0
+    image: docker.io/opensearchproject/opensearch:2.14.0
     networks:
       - temporal-network
     expose:
@@ -36,7 +36,7 @@ services:
       retries: 5
       start_period: 30s
   postgresql:
-    image: bitnami/postgresql:latest
+    image: docker.io/bitnami/postgresql:latest
     # container_name: code-confluence-postgresql
     environment:
       - POSTGRESQL_USERNAME=postgres
@@ -73,7 +73,7 @@ services:
       - ES_VERSION=v7
       # - SKIP_SCHEMA_SETUP=false
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/auto-setup:1.26.2
+    image: docker.io/temporalio/auto-setup:1.26.2
     networks:
       - temporal-network
     ports:
@@ -94,7 +94,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.26.2
+    image: docker.io/temporalio/admin-tools:1.26.2
     networks:
       - temporal-network
     stdin_open: true
@@ -107,14 +107,14 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
       - TEMPORAL_CSRF_COOKIE_INSECURE=True
-    image: temporalio/ui:2.34.0
+    image: docker.io/temporalio/ui:2.34.0
     networks:
       - temporal-network
     ports:
       - 8081:8080
   neo4j:
     # container_name: neo4j
-    image: graphstack/dozerdb:5.25.1.0-alpha.1
+    image: docker.io/graphstack/dozerdb:5.25.1.0-alpha.1
     ports:
       - "7474:7474"
       - "7687:7687"

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
       - OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m
-    image: opensearchproject/opensearch:2.14.0
+    image: docker.io/opensearchproject/opensearch:2.14.0
     networks:
       - temporal-network
     expose:
@@ -35,7 +35,7 @@ services:
       retries: 5
       start_period: 30s
   postgresql:
-    image: bitnami/postgresql:latest
+    image: docker.io/bitnami/postgresql:latest
     environment:
       - POSTGRESQL_USERNAME=postgres
       - POSTGRESQL_PASSWORD=postgres
@@ -67,7 +67,7 @@ services:
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/auto-setup:1.26.2
+    image: docker.io/temporalio/auto-setup:1.26.2
     networks:
       - temporal-network
     ports:
@@ -87,7 +87,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.26.2
+    image: docker.io/temporalio/admin-tools:1.26.2
     networks:
       - temporal-network
     stdin_open: true
@@ -99,13 +99,13 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
       - TEMPORAL_CSRF_COOKIE_INSECURE=True
-    image: temporalio/ui:2.34.0
+    image: docker.io/temporalio/ui:2.34.0
     networks:
       - temporal-network
     ports:
       - 8081:8080
   neo4j:
-    image: graphstack/dozerdb:5.25.1.0-alpha.1
+    image: docker.io/graphstack/dozerdb:5.25.1.0-alpha.1
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add `docker.io` prefix to all Docker images in compose files

- Update README feature table with detailed ingestion options


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Docker Compose Files"] --> B["Add docker.io prefix"]
  B --> C["Temporal Services"]
  B --> D["Database Services"]
  B --> E["Search Services"]
  F["README"] --> G["Update Feature Table"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local-docker-compose.yml</strong><dd><code>Add docker.io prefix to all images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

local-docker-compose.yml

<li>Add <code>docker.io/</code> prefix to opensearchproject/opensearch image<br> <li> Add <code>docker.io/</code> prefix to bitnami/postgresql image<br> <li> Add <code>docker.io/</code> prefix to temporalio/auto-setup image<br> <li> Add <code>docker.io/</code> prefix to temporalio/admin-tools and temporalio/ui <br>images<br> <li> Add <code>docker.io/</code> prefix to graphstack/dozerdb image


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/642/files#diff-8c72c135c221eaa1e6e3f49107222f05dc58a63dbf4ce1d17e4eb505081a543a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prod-docker-compose.yml</strong><dd><code>Add docker.io prefix to all images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prod-docker-compose.yml

<li>Add <code>docker.io/</code> prefix to opensearchproject/opensearch image<br> <li> Add <code>docker.io/</code> prefix to bitnami/postgresql image<br> <li> Add <code>docker.io/</code> prefix to temporalio/auto-setup image<br> <li> Add <code>docker.io/</code> prefix to temporalio/admin-tools and temporalio/ui <br>images<br> <li> Add <code>docker.io/</code> prefix to graphstack/dozerdb image


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/642/files#diff-64e4d2f336545fbe032c79e278c56e9c88f737b42dbec0bf431b347d1f6c1d33">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Expand ingestion feature details in table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Replace generic "Ingestion" row with specific ingestion types<br> <li> Add "GitHub Ingestion" and "GitHub Manual Sync" entries<br> <li> Add "Local Ingestion" and "Local Manual Sync" entries


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/642/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>