### PR TITLE
fix(docker): mount local repositories directory

### DIFF
--- a/code-confluence/docs/quickstart/how-to-run.md
+++ b/code-confluence/docs/quickstart/how-to-run.md
@@ -83,7 +83,14 @@ You can ingest repositories from two sources:
 ![Local Repository Onboarding](../../static/local_onboarding_repo.png)
 
 :::note Docker Configuration for Local Repositories
-The production Docker Compose configuration is pre-configured with volume mounting (`${HOME}/.unoplat:/root/.unoplat`) and sets the environment variable `REPOSITORIES_BASE_PATH=/root/.unoplat/repositories` in the flow-bridge service to enable local repository ingestion. You can modify these paths in the Docker Compose file to match your preferred directory structure if needed.
+The Docker Compose is pre-configured with volume mounting (`${HOME}/unoplat/repositories:/root/.unoplat/repositories`) and sets the environment variable `REPOSITORIES_BASE_PATH=/root/.unoplat/repositories` in the flow-bridge service to enable local repository ingestion. 
+
+Before using local repositories, create the required directory on your host machine:
+```bash
+mkdir -p ~/unoplat/repositories
+```
+
+You can modify these paths in the Docker Compose file to match your preferred directory structure if needed, but ensure the volume mount path remains consistent with the `REPOSITORIES_BASE_PATH` environment variable in the `code-confluence-flow-bridge` service configuration.
 :::
 
 ### 4. Continue with Repository Configuration

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -148,7 +148,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ${HOME}/.unoplat:/root/.unoplat
+      - ${HOME}/unoplat/repositories:/root/.unoplat/repositories
     networks:
       - temporal-network
     stdin_open: true


### PR DESCRIPTION
### **User description**
The changes in this commit update the volume mount configuration in the
production Docker Compose file to use a custom directory for local
repositories instead of the default `~/.unoplat` directory. This allows
users to easily manage their local repository files outside of the
default location.

Additionally, the documentation has been updated to provide instructions
on creating the required directory structure on the host machine before
using local repositories.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Update Docker volume mount path for local repositories

- Add setup instructions for creating required directory

- Improve documentation clarity and consistency


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Host Directory"] -- "Volume Mount" --> B["Container Path"]
  C["Documentation"] -- "Setup Instructions" --> A
  A --> D["~/unoplat/repositories"]
  B --> E["/root/.unoplat/repositories"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>how-to-run.md</strong><dd><code>Enhanced local repository setup documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

code-confluence/docs/quickstart/how-to-run.md

<li>Update volume mount path from <code>~/.unoplat</code> to <code>~/unoplat/repositories</code><br> <li> Add bash command for creating required directory structure<br> <li> Enhance documentation with clearer setup instructions<br> <li> Improve note formatting and consistency requirements


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/643/files#diff-2553ac66167b941cd83852f2219a419329fb24c4f7ad355dbda86942ad37fe1c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prod-docker-compose.yml</strong><dd><code>Updated Docker volume mount configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prod-docker-compose.yml

<li>Change volume mount from <code>${HOME}/.unoplat:/root/.unoplat</code> to <br><code>${HOME}/unoplat/repositories:/root/.unoplat/repositories</code><br> <li> More specific directory mapping for local repositories


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/643/files#diff-64e4d2f336545fbe032c79e278c56e9c88f737b42dbec0bf431b347d1f6c1d33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>