### PR TITLE
fix(docs): Simplify local repository onboarding instructions

### DIFF
--- a/code-confluence/docs/quickstart/how-to-run.md
+++ b/code-confluence/docs/quickstart/how-to-run.md
@@ -78,7 +78,7 @@ You can ingest repositories from two sources:
 #### B. Browse Local Git Repositories
 - Click on the **Local Repository** tab to switch to local repository onboarding.
 - Click the **Browse** button to select a local Git repository from your machine.
-- Note: Your repository must be located within the directory configured by the backend's REPOSITORIES_BASE_PATH setting.
+
 
 ![Local Repository Onboarding](../../static/local_onboarding_repo.png)
 


### PR DESCRIPTION
### **User description**
The changes remove the note about the repository location requirement, as this
detail is not essential for the quickstart guide. The goal is to provide a
more concise and user-friendly onboarding experience for local Git repository
browsing.


___

### **PR Type**
Documentation


___

### **Description**
- Remove repository location requirement note from quickstart guide

- Simplify local Git repository onboarding instructions


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Quickstart Guide"] --> B["Local Repository Section"]
  B --> C["Remove Location Note"]
  C --> D["Simplified Instructions"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>how-to-run.md</strong><dd><code>Remove repository location requirement note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

code-confluence/docs/quickstart/how-to-run.md

<li>Remove note about <code>REPOSITORIES_BASE_PATH</code> requirement<br> <li> Simplify local repository onboarding instructions


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/645/files#diff-2553ac66167b941cd83852f2219a419329fb24c4f7ad355dbda86942ad37fe1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>