### PR TITLE
fix: better docs

### DIFF
--- a/code-confluence/docs/quickstart/how-to-run.md
+++ b/code-confluence/docs/quickstart/how-to-run.md
@@ -85,7 +85,7 @@ You can ingest repositories from two sources:
 :::note Docker Configuration for Local Repositories
 The Docker Compose is pre-configured with volume mounting (`${HOME}/unoplat/repositories:/root/.unoplat/repositories`) and sets the environment variable `REPOSITORIES_BASE_PATH=/root/.unoplat/repositories` in the flow-bridge service to enable local repository ingestion. 
 
-Before using local repositories, create the required directory on your host machine:
+Before using local repositories, create the required directory on your host machine and clone your Git repositories into this path:
 ```bash
 mkdir -p ~/unoplat/repositories
 ```


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Clarified local repository setup instructions in quickstart guide


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>how-to-run.md</strong><dd><code>Clarify local repository setup instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

code-confluence/docs/quickstart/how-to-run.md

<li>Enhanced instruction text to clarify that Git repositories should be <br>cloned into the local directory path


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/647/files#diff-2553ac66167b941cd83852f2219a419329fb24c4f7ad355dbda86942ad37fe1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>