### PR TITLE
fix(config): Add FRAMEWORK_DEFINITIONS_PATH environment variable

### DIFF
--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -139,6 +139,7 @@ services:
       - TEMPORAL_DEBUG=false
       - LOG_LEVEL=DEBUG
       - REPOSITORIES_BASE_PATH=/root/.unoplat/repositories
+      - FRAMEWORK_DEFINITIONS_PATH=/app/framework-definitions
     image: ghcr.io/unoplat/code-confluence-flow-bridge:0.41.0
     depends_on:
       temporal:


### PR DESCRIPTION
### **User description**
Adds a new environment variable FRAMEWORK_DEFINITIONS_PATH to the
code-confluence-flow-bridge service in the prod-docker-compose.yml file.
This allows configuring the path where the framework definitions are
located, which is necessary for the application to function correctly.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `FRAMEWORK_DEFINITIONS_PATH` environment variable to production configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["prod-docker-compose.yml"] --> B["code-confluence-flow-bridge service"]
  B --> C["FRAMEWORK_DEFINITIONS_PATH=/app/framework-definitions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prod-docker-compose.yml</strong><dd><code>Add framework definitions path environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prod-docker-compose.yml

<ul><li>Add <code>FRAMEWORK_DEFINITIONS_PATH</code> environment variable to <br>code-confluence-flow-bridge service<br> <li> Set path to <code>/app/framework-definitions</code> for framework definitions <br>location</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/659/files#diff-64e4d2f336545fbe032c79e278c56e9c88f737b42dbec0bf431b347d1f6c1d33">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

