### PR TITLE
feat(github-actions): Migrate from Poetry to uv for Python builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ This workflow runs on pull requests to the `main` branch that include changes to
 - `unoplat-code-confluence-ingestion`
 
 It performs the following tasks:
-- Builds Python packages using Poetry
+- Builds Python packages using uv
 - Runs tests with pytest and generates coverage reports
 - Uploads test coverage reports as artifacts
 

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -28,17 +28,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: "1.8.3"
-      - name: Check poetry version
-        run: poetry --version
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install dependencies
         working-directory: ${{ matrix.path }}
-        run: poetry install --no-root
-      - name: Build poetry
+        run: uv sync
+      - name: Build package
         working-directory: ${{ matrix.path }}
-        run: poetry build -f wheel
+        run: uv build
         
   test-uv-projects:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Migrate the Python package build and dependency management from Poetry 
to the uv tool. This change simplifies the GitHub Actions workflow and
reduces the number of steps required to build and test the Python
packages.

The key changes are:

- Replace the `Gr1N/setup-poetry` action with the `astral-sh/setup-uv`
  action to install the uv tool.
- Replace the `poetry install` and `poetry build` commands with the
  corresponding `uv sync` and `uv build` commands.

This change aims to streamline the GitHub Actions workflow and make it
more maintainable by using a simpler and more lightweight dependency
management tool.