### PR TITLE
fix: Install ripgrep in Python build workflow

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -82,6 +82,11 @@ jobs:
 
       - name: Install Ruff
         run: curl -LsSf https://astral.sh/ruff/install.sh | sh
+
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
         
       - name: Install dependencies and run tests
         working-directory: ${{ matrix.project }}


### PR DESCRIPTION
### **User description**
Adds a step to install the ripgrep tool in the Python build
workflow. Ripgrep is a fast and efficient file search tool that
can be useful for various development tasks.


___

### **PR Type**
Other


___

### **Description**
- Add ripgrep installation to Python build workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Python Build Workflow"] --> B["Install Ruff"]
  B --> C["Install ripgrep"]
  C --> D["Install dependencies and run tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_build.yaml</strong><dd><code>Add ripgrep installation step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python_build.yaml

<ul><li>Add new step to install ripgrep using apt-get<br> <li> Insert installation step between Ruff and dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/676/files#diff-acffa834ca92a0147495c1b31c0f6fbe52107d39165a10e37fcd2f4357f4ad31">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

