### PR TITLE
fix: linting moved the annotation import

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/ruff.toml
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/ruff.toml
@@ -33,5 +33,5 @@ force-to-top = ["os","sys"]
 force-sort-within-sections = true
 combine-as-imports = true
 from-first = true
-section-order = ["first-party", "local-folder","future", "standard-library", "third-party"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 lines-between-types = 2 


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Moved import statements to follow PEP8 conventions

- Fixed code formatting and spacing issues

- Added type annotations for better code clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Standard library imports"] --> B["Third-party imports"]
  B --> C["Local imports"]
  C --> D["Formatted code blocks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_ripgrep_detector.py</strong><dd><code>Import reordering and code formatting fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/detectors/python_ripgrep_detector.py

<ul><li>Reordered imports to follow PEP8 standard (stdlib, third-party, local)<br> <li> Fixed spacing and formatting in method definitions<br> <li> Added proper line breaks and indentation<br> <li> Improved code readability with consistent formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/678/files#diff-fd08a294c0c3692b14e3b62c7508deeb68c5ca74aa31be613b683e8f94ea05d6">+31/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

