### PR TITLE
feat: Add repository and programming language models

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
@@ -24,6 +24,14 @@ from unoplat_code_confluence_commons.base_models import (
     TargetLevel,
     # Structural signature models
     VariableInfo,
+    # Repository and Programming Language models
+    Repository,
+    CodebaseConfigSQLModel,
+    CodebaseConfig,
+    RepositorySettings,
+    ProgrammingLanguageMetadata,
+    ProgrammingLanguage,
+    PackageManagerType,
 )
 from unoplat_code_confluence_commons.graph_models import (
     BaseNode,
@@ -70,4 +78,12 @@ __all__ = [
     'Framework',
     'FrameworkFeature',
     'FeatureAbsolutePath',
+    # Repository and Programming Language models
+    'Repository',
+    'CodebaseConfigSQLModel',
+    'CodebaseConfig',
+    'RepositorySettings',
+    'ProgrammingLanguageMetadata',
+    'ProgrammingLanguage',
+    'PackageManagerType',
 ]

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/__init__.py
@@ -29,6 +29,21 @@ from .framework_models import (
     FeatureAbsolutePath,
 )
 
+# Repository and Programming Language models
+from ..repo_models import (
+    Repository,
+    CodebaseConfig as CodebaseConfigSQLModel,
+)
+from ..programming_language_metadata import (
+    ProgrammingLanguageMetadata,
+    ProgrammingLanguage,
+    PackageManagerType,
+)
+from ..configuration_models import (
+    CodebaseConfig,
+    RepositorySettings,
+)
+
 __all__ = [
     # Structural signature models
     "VariableInfo",
@@ -50,4 +65,12 @@ __all__ = [
     "Framework",
     "FrameworkFeature",
     "FeatureAbsolutePath",
+    # Repository and Programming Language models
+    "Repository",
+    "CodebaseConfigSQLModel",
+    "CodebaseConfig",
+    "RepositorySettings",
+    "ProgrammingLanguageMetadata",
+    "ProgrammingLanguage", 
+    "PackageManagerType",
 ]

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/configuration_models.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/configuration_models.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from .programming_language_metadata import ProgrammingLanguageMetadata
+
+
+class CodebaseConfig(BaseModel):
+    """Pydantic model for codebase configuration in JSON config files."""
+    codebase_folder: str  
+    root_packages: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Relative paths (POSIX) to each root package inside codebase_folder."
+        ),
+    )
+    programming_language_metadata: ProgrammingLanguageMetadata
+
+
+class RepositorySettings(BaseModel):
+    """Pydantic model for repository settings in JSON config files."""
+    git_url: str
+    output_path: str
+    codebases: List[CodebaseConfig]

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/programming_language_metadata.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/programming_language_metadata.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ProgrammingLanguage(str, Enum):
+    PYTHON = "python"
+
+
+class PackageManagerType(str, Enum):
+    POETRY = "poetry"
+    PIP = "pip"
+    UV = "uv"
+
+
+class ProgrammingLanguageMetadata(BaseModel):
+    language: ProgrammingLanguage
+    package_manager: Optional[PackageManagerType] = None
+    language_version: Optional[str] = None
+    manifest_path: Optional[str] = None
+    project_name: Optional[str] = None

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKeyConstraint, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Repository(SQLModel, table=True):
+    """SQLModel for repository table in code_confluence schema."""
+    __tablename__ = "repository"
+
+    repository_name: str = Field(primary_key=True, description="The name of the repository")
+    repository_owner_name: str = Field(primary_key=True, description="The name of the repository owner")
+    is_local: bool = Field(default=False, description="Whether this is a local repository")
+    local_path: Optional[str] = Field(default=None, description="Local filesystem path for local repositories")
+    
+    # Relationships - will be populated after class definitions
+    workflow_runs: List["RepositoryWorkflowRun"] = Relationship(
+        back_populates="repository",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+            "passive_deletes": True,
+        },
+    )
+    configs: List["CodebaseConfig"] = Relationship(
+        back_populates="repository",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+            "passive_deletes": True,
+        },
+    )
+
+
+class CodebaseConfig(SQLModel, table=True):
+    """SQLModel for codebase_config table in code_confluence schema."""
+    __tablename__ = "codebase_config"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["repository_name", "repository_owner_name"],
+            ["repository.repository_name", "repository.repository_owner_name"],
+            ondelete="CASCADE"
+        ),
+    )
+    
+    repository_name: str = Field(
+        primary_key=True, 
+        description="The name of the repository"
+    )
+    repository_owner_name: str = Field(
+        primary_key=True, 
+        description="The name of the repository owner"
+    )
+    codebase_folder: str = Field(
+        primary_key=True, 
+        description="Path to codebase folder relative to repo root"
+    )
+    root_packages: Optional[List[str]] = Field(
+        default=None,
+        sa_column=Column(JSONB),
+        description="List of root packages within the codebase folder"
+    )
+    programming_language_metadata: Dict[str, Any] = Field(
+        sa_column=Column(JSONB, nullable=False),
+        description="Language-specific metadata for this codebase like programming language, package manager etc"
+    )
+    
+    # Relationships
+    repository: Repository = Relationship(back_populates="configs")
+    workflow_runs: List["CodebaseWorkflowRun"] = Relationship(
+        back_populates="codebase_config",
+        sa_relationship_kwargs={
+            "viewonly": True,
+            "overlaps": "repository_workflow_run,workflow_runs",
+        },
+    )

--- a/unoplat-code-confluence-commons/uv.lock
+++ b/unoplat-code-confluence-commons/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.21.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "neomodel" },


### PR DESCRIPTION
### **User description**
This commit introduces new models for managing repository and programming language metadata in the code confluence project. The key changes are:

- Added `CodebaseConfig` and `RepositorySettings` models to handle codebase and repository configuration details.
- Added `ProgrammingLanguageMetadata`, `ProgrammingLanguage`, and `PackageManagerType` models to capture programming language-specific metadata.
- Integrated these new models into the existing `Repository` and `CodebaseConfig` SQLModel classes.
- Updated the `__init__.py` files to expose the new models.

These changes will enable the code confluence project to better manage and represent the various codebases and their associated programming language details.


___

### **PR Type**
Enhancement


___

### **Description**
- Add repository and programming language models for metadata management

- Introduce configuration models for codebase and repository settings

- Create SQLModel classes for database persistence

- Update module exports to expose new models


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Programming Language Models"] --> B["Configuration Models"]
  B --> C["Repository SQLModels"]
  C --> D["Module Exports"]
  A --> E["ProgrammingLanguage Enum"]
  A --> F["PackageManagerType Enum"]
  B --> G["CodebaseConfig Pydantic"]
  B --> H["RepositorySettings Pydantic"]
  C --> I["Repository SQLModel"]
  C --> J["CodebaseConfig SQLModel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Update main module exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py

<ul><li>Add imports for new repository and programming language models<br> <li> Update <code>__all__</code> list to export new model classes</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/684/files#diff-2d6c5fd2e21027f0dc107ed1c4f30ee737aabbf48d7d0d9f461fb52d5c82eb15">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Update base models module exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/__init__.py

<ul><li>Import repository models from <code>repo_models</code> module<br> <li> Import programming language models from <code>programming_language_metadata</code><br> <li> Import configuration models from <code>configuration_models</code><br> <li> Add all new models to <code>__all__</code> exports</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/684/files#diff-64a78077b38397ca41425d52555d687fc94ce439664a8c7aae854c2ed3627bd0">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration_models.py</strong><dd><code>Add Pydantic configuration models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/configuration_models.py

<ul><li>Create <code>CodebaseConfig</code> Pydantic model for JSON configuration<br> <li> Create <code>RepositorySettings</code> model with git URL and codebases<br> <li> Define codebase folder and root packages structure</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/684/files#diff-a73dfa923137098f60ff77b3f62892eacb1bd92d125204f3f7a7ef537ee31240">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>programming_language_metadata.py</strong><dd><code>Add programming language metadata models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/programming_language_metadata.py

<ul><li>Define <code>ProgrammingLanguage</code> enum with Python support<br> <li> Define <code>PackageManagerType</code> enum for Poetry, Pip, UV<br> <li> Create <code>ProgrammingLanguageMetadata</code> model with language details</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/684/files#diff-893f45a4c176364a6a689d08e2dee282eec4c27f7d82c7977845fc9d4c6ac454">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repo_models.py</strong><dd><code>Add repository SQLModel classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py

<ul><li>Create <code>Repository</code> SQLModel with primary key constraints<br> <li> Create <code>CodebaseConfig</code> SQLModel with foreign key relationships<br> <li> Define JSONB columns for metadata and root packages<br> <li> Set up cascade delete relationships between models</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/684/files#diff-f2e444caa052dd965111a885baa0a293e85e3ae046e18f4410fe49f4485ce53d">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

