### PR TITLE
feat: add Discord notification on release publish

### DIFF
--- a/.github/workflows/publish_discord.yml
+++ b/.github/workflows/publish_discord.yml
@@ -1,0 +1,14 @@
+name: unoplat_code_confluence_discord
+
+on:
+  release:
+    types: [published]   # fires only when a release is published
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send nicely-formatted embed to Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.DISCORD_UNOPLAT_CODE_CONFLUENCE_WEBHOOK }}


### PR DESCRIPTION
### **User description**
Adds a GitHub Actions workflow to send a nicely-formatted embed to a
Discord webhook when a new release is published. This will help keep the
Uno Platform Code Confluence Discord server up-to-date with the latest
releases.


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub Actions workflow for Discord notifications

- Trigger on release publish events

- Send formatted embeds to Discord webhook


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Release Published"] --> B["GitHub Actions Workflow"]
  B --> C["Discord Webhook"]
  C --> D["Uno Platform Discord Server"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish_discord.yml</strong><dd><code>Add Discord release notification workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish_discord.yml

<ul><li>Create new GitHub Actions workflow file<br> <li> Configure trigger on release publish events<br> <li> Add Discord webhook notification step<br> <li> Use SethCohen/github-releases-to-discord action</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/694/files#diff-cacda6cadb0de26e4e987ad994363ad88ed9131432a657d1650e8d8f52e6f6e8">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

