### PR TITLE
fix(code-confluence-file): change to `has_data_model` property from is_data_model

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/graph_models/code_confluence_file.py
@@ -11,6 +11,7 @@ from neomodel import (
     AsyncRelationshipTo,
     AsyncStructuredNode,
     AsyncZeroOrMore,
+    BooleanProperty,
     JSONProperty,
     StringProperty,
 )
@@ -39,6 +40,7 @@ class CodeConfluenceFile(AsyncStructuredNode):
         default=[]
     )
     class_variables = JSONProperty(default={})
+    has_data_model = BooleanProperty(default=False, index=True)
     # Relationship to framework features detected in this file
       # local import to avoid cycles
 

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/code_confluence_parsing_models/unoplat_file.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/code_confluence_parsing_models/unoplat_file.py
@@ -28,7 +28,7 @@ class UnoplatFile(BaseModel):
         description="List of custom features detected in the file"
     )
     
-    is_data_model: bool = Field(
+    has_data_model: bool = Field(
         default=False,
-        description="True if file defines a Python data model (e.g., @dataclass)"
+        description="True if file contains classes that are data models (e.g., @dataclass)"
     )

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py
@@ -388,7 +388,7 @@ class GenericCodebaseParser:
             imports = await asyncio.to_thread(self._extract_imports_from_source,content)
 
             # Detect if file contains data models
-            is_data_model = detect_data_model(
+            has_data_model = detect_data_model(
                 source_code=content,
                 imports=imports,
                 language=self.programming_language_metadata.language.value,
@@ -420,7 +420,7 @@ class GenericCodebaseParser:
                 structural_signature=signature,  # Store the actual object, not dict
                 imports=imports,
                 custom_features_list=custom_features_list,
-                is_data_model=is_data_model,
+                has_data_model=has_data_model,
             )
 
             return unoplat_file
@@ -720,7 +720,7 @@ class GenericCodebaseParser:
                     if unoplat_file.structural_signature
                     else "{}",
                     "imports": unoplat_file.imports or [],
-                    "is_data_model": unoplat_file.is_data_model,
+                    "has_data_model": unoplat_file.has_data_model,
                 }
 
                 # Follow neomodel's create_or_update pattern: MERGE only on required properties (file_path)
@@ -730,12 +730,12 @@ class GenericCodebaseParser:
                     f.checksum = $checksum,
                     f.structural_signature = $structural_signature,
                     f.imports = $imports,
-                    f.is_data_model = $is_data_model
+                    f.has_data_model = $has_data_model
                 ON MATCH SET 
                     f.checksum = $checksum,
                     f.structural_signature = $structural_signature,
                     f.imports = $imports,
-                    f.is_data_model = $is_data_model
+                    f.has_data_model = $has_data_model
                 RETURN f
                 """
 

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/test_generic_codebase_parser.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/test_generic_codebase_parser.py
@@ -357,32 +357,32 @@ class TestGenericCodebaseParserIntegration:
                 continue  # allow empty imports for package init files
             assert file_imports is not None, f"File {file_path} missing imports list"
 
-        # 10. Verify is_data_model field for dataclass files
+        # 10. Verify has_data_model field for dataclass files
         result, _ = neo4j_client.cypher_query(
             "MATCH (f:CodeConfluenceFile) WHERE f.file_path CONTAINS 'user_model.py' "
-            "RETURN f.file_path, f.is_data_model, f.imports"
+            "RETURN f.file_path, f.has_data_model, f.imports"
         )
 
         assert len(result) == 1, "Expected to find user_model.py"
-        _, is_data_model, imports = result[0]
+        _, has_data_model, imports = result[0]
 
         # Verify the file is correctly marked as a data model
-        assert is_data_model is True, "user_model.py should be marked as is_data_model=True"
+        assert has_data_model is True, "user_model.py should be marked as has_data_model=True"
         assert any("dataclass" in imp.lower() for imp in imports), "user_model.py should have dataclass imports"
 
         # 11. Verify non-dataclass files are marked correctly
         result, _ = neo4j_client.cypher_query(
             "MATCH (f:CodeConfluenceFile) WHERE f.file_path CONTAINS 'api_client.py' "
-            "RETURN f.file_path, f.is_data_model"
+            "RETURN f.file_path, f.has_data_model"
         )
 
         assert len(result) == 1, "Expected to find api_client.py"
-        _, api_is_data_model = result[0]
-        assert api_is_data_model is False, "api_client.py should be marked as is_data_model=False"
+        _, api_has_data_model = result[0]
+        assert api_has_data_model is False, "api_client.py should be marked as has_data_model=False"
 
         # 12. Count total dataclass vs non-dataclass files
         result, _ = neo4j_client.cypher_query(
-            "MATCH (f:CodeConfluenceFile) RETURN f.is_data_model, COUNT(f) as count"
+            "MATCH (f:CodeConfluenceFile) RETURN f.has_data_model, COUNT(f) as count"
         )
 
         dataclass_count = 0
@@ -430,7 +430,7 @@ class TestGenericCodebaseParserIntegration:
         unoplat_file = await parser.extract_file_data(str(dataclass_file))
         
         assert unoplat_file is not None
-        assert unoplat_file.is_data_model is True
+        assert unoplat_file.has_data_model is True
         assert any("dataclass" in imp.lower() for imp in unoplat_file.imports)
         
         # Test non-dataclass file
@@ -438,7 +438,7 @@ class TestGenericCodebaseParserIntegration:
         regular_unoplat_file = await parser.extract_file_data(str(regular_file))
         
         assert regular_unoplat_file is not None
-        assert regular_unoplat_file.is_data_model is False
+        assert regular_unoplat_file.has_data_model is False
         
         logger.info("extract_file_data dataclass detection test passed")
     

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.46.1"
+version = "0.47.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
### **User description**
The changes introduce a new `BooleanProperty` called `has_data_model`
to the `CodeConfluenceFile` model. This property is used to indicate 
whether a file contains classes that are data models (e.g., 
`@dataclass`). The changes also update the related code in the 
`GenericCodebaseParser` to detect and set this property correctly.


___

### **PR Type**
Bug fix


___

### **Description**
- Rename `is_data_model` property to `has_data_model`

- Update property description for clarity

- Fix naming convention across codebase

- Update database queries and tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UnoplatFile Model"] --> B["has_data_model Property"]
  B --> C["CodeConfluenceFile Graph Model"]
  C --> D["Database Queries"]
  D --> E["Test Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_confluence_file.py</strong><dd><code>Add has_data_model property to graph model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/graph_models/code_confluence_file.py

<ul><li>Add <code>BooleanProperty</code> import<br> <li> Add <code>has_data_model</code> property with default False and index</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/698/files#diff-8c909410623579351681613c008990763e2266914d95f25cdd85e8c1a3ec03a0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unoplat_file.py</strong><dd><code>Rename field in UnoplatFile model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/code_confluence_parsing_models/unoplat_file.py

<ul><li>Rename <code>is_data_model</code> field to <code>has_data_model</code><br> <li> Update field description for better clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/698/files#diff-6c67d1abcff3e8767b7343f931f8f29f363a8bc40484cb0d3839c4809ae675ca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generic_codebase_parser.py</strong><dd><code>Update parser logic for renamed property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py

<ul><li>Update variable name from <code>is_data_model</code> to <code>has_data_model</code><br> <li> Update UnoplatFile instantiation parameter<br> <li> Update Cypher queries for database operations</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/698/files#diff-d647986e19cf71de4c0f762a829fe38402b2a106b126324cbb7992ff1d4c7cee">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_generic_codebase_parser.py</strong><dd><code>Update tests for renamed property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/test_generic_codebase_parser.py

<ul><li>Update test assertions to use <code>has_data_model</code><br> <li> Update Cypher queries in tests<br> <li> Update variable names in test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/698/files#diff-4d7453c7cfb6c38e987967beed73e099c9f8708e1d2071c30ec4746ab87337c8">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

