### PR TITLE
fix(release-management): Use Personal Access Token for release-please-action

### DIFF
--- a/.github/workflows/discord-release-notification.yaml
+++ b/.github/workflows/discord-release-notification.yaml
@@ -1,0 +1,25 @@
+name: Discord Release Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-discord:
+    name: Send Discord Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Release Notification
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.DISCORD_UNOPLAT_CODE_CONFLUENCE_WEBHOOK }}
+          color: 2105893
+          username: "Unoplat Release Bot"
+          avatar_url: "https://avatars.githubusercontent.com/${{ github.repository_owner }}"
+          content: "@everyone"
+          footer_title: "Unoplat Code Confluence"
+          footer_icon_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          footer_timestamp: true
+          max_description: 4096
+          remove_github_reference_links: false
+          reduce_headings: false

--- a/.github/workflows/publish_release_management.yaml
+++ b/.github/workflows/publish_release_management.yaml
@@ -29,7 +29,7 @@ jobs:
       id: release_action_plan
       uses: googleapis/release-please-action@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT }}  # Changed from GITHUB_TOKEN to use Personal Access Token
         config-file: .github/configuration/release-please-config.json
         manifest-file: .github/configuration/release-please-manifest.json
         include-component-in-tag: true
@@ -128,15 +128,5 @@ jobs:
             
       #       console.log(`Updated image to: ${newImage}`);
 
-  discord-notification:
-    name: Send Discord Release Notification
-    runs-on: ubuntu-latest
-    needs: main-pr-merge
-    if: needs.main-pr-merge.outputs.release_created == 'true'
-    steps:
-      - name: Send Discord notifications
-        uses: SethCohen/github-releases-to-discord@v1
-        with:
-          webhook_url: ${{ secrets.DISCORD_UNOPLAT_CODE_CONFLUENCE_WEBHOOK }}
 
 


### PR DESCRIPTION
### **User description**
Switches the token used by the release-please-action from the default
GITHUB_TOKEN to a Personal Access Token. This allows the action to have
broader permissions and access to resources beyond just the current
repository.

The DISCORD_UNOPLAT_CODE_CONFLUENCE_WEBHOOK secret is also moved to a
dedicated Discord release notification workflow.


___

### **PR Type**
Enhancement


___

### **Description**
- Switch release-please-action to use Personal Access Token

- Create dedicated Discord release notification workflow

- Remove Discord notification from main release workflow

- Improve workflow separation and permissions management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Please Action"] -- "uses PAT instead of GITHUB_TOKEN" --> B["Enhanced Permissions"]
  C["Main Release Workflow"] -- "Discord notification removed" --> D["Cleaner Workflow"]
  E["New Discord Workflow"] -- "triggered on release published" --> F["Discord Notification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>discord-release-notification.yaml</strong><dd><code>Add dedicated Discord release notification workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/discord-release-notification.yaml

<ul><li>Create new workflow triggered on release published events<br> <li> Configure Discord notification with webhook and custom settings<br> <li> Set up bot appearance with avatar and username</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/700/files#diff-fac81cc3e0d41df40e469cffe7d691e75a744bd52194a1c8c78fceccf536fa47">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>publish_release_management.yaml</strong><dd><code>Update token and remove Discord notification job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish_release_management.yaml

<ul><li>Replace <code>GITHUB_TOKEN</code> with <code>PAT</code> for release-please-action<br> <li> Remove entire <code>discord-notification</code> job section<br> <li> Add comment explaining token change rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/700/files#diff-9b07d83b74ab65bfc8626c6a12337256e2b98931797f7172358a1bef312afee4">+1/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

