### PR TITLE
fix: Update unoplat-code-confluence-commons dependency to v0.24.1

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/pyproject.toml
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 [tool.uv.sources]
 #NOTE: use it for local development to instantly see changes in the schema and its impact
 #unoplat-code-confluence-commons = { path = "../../unoplat-code-confluence-commons" }
-unoplat-code-confluence-commons = { git = "https://github.com/unoplat/unoplat-code-confluence.git", subdirectory = "unoplat-code-confluence-commons", rev = "unoplat-code-confluence-commons-v0.24.0" }
+unoplat-code-confluence-commons = { git = "https://github.com/unoplat/unoplat-code-confluence.git", subdirectory = "unoplat-code-confluence-commons", rev = "unoplat-code-confluence-commons-v0.24.1" }
 
 
 [tool.uv]

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.47.0"
+version = "0.47.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },
@@ -356,7 +356,7 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "tree-sitter-language-pack", specifier = ">=0.8.0" },
     { name = "typing-extensions", specifier = ">=4.11" },
-    { name = "unoplat-code-confluence-commons", git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.24.0" },
+    { name = "unoplat-code-confluence-commons", git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.24.1" },
     { name = "validate-pyproject", extras = ["all"], specifier = ">=0.23" },
 ]
 
@@ -2059,8 +2059,8 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.24.0"
-source = { git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.24.0#6107e2911587c2d458a41954ce4498e44dad3f47" }
+version = "0.24.1"
+source = { git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.24.1#213e5d478537a3585c0cd56d4da21099afb1304c" }
 dependencies = [
     { name = "neomodel" },
     { name = "pydantic" },


### PR DESCRIPTION
### **User description**
Updates the unoplat-code-confluence-commons dependency to version 0.24.1 in the
pyproject.toml and uv.lock files. This change is necessary to incorporate the
latest updates and bug fixes from the unoplat-code-confluence-commons library.


___

### **PR Type**
Other


___

### **Description**
- Update `unoplat-code-confluence-commons` dependency to v0.24.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pyproject.toml"] -- "version bump" --> B["v0.24.0 → v0.24.1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump commons dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/pyproject.toml

<ul><li>Updated git revision from <code>unoplat-code-confluence-commons-v0.24.0</code> to <br><code>unoplat-code-confluence-commons-v0.24.1</code></ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/701/files#diff-b9ff793e6fa07f126e8b12de38d04175c184ea292ad2de1f00ab830834459722">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

