### PR TITLE
feat(discord-notification): Update release notification message

### DIFF
--- a/.github/workflows/discord-release-notification.yaml
+++ b/.github/workflows/discord-release-notification.yaml
@@ -16,7 +16,7 @@ jobs:
           color: 2105893
           username: "Unoplat Release Bot"
           avatar_url: "https://avatars.githubusercontent.com/${{ github.repository_owner }}"
-          content: "@everyone"
+          content: "Certified fresh… until the next release"
           footer_title: "Unoplat Code Confluence"
           footer_icon_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           footer_timestamp: true


### PR DESCRIPTION
The changes update the Discord release notification message to be more
engaging and informative. The previous message of "@everyone" is
replaced with a more descriptive and inviting message "Certified
fresh… until the next release". This will also ensure that we do not 
disturb everyone in the community for frequent releases and only on 
biweekly releases