### PR TITLE
feat: Add framework/library description field

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/framework_models.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/framework_models.py
@@ -20,6 +20,7 @@ class Framework(SQLModel, table=True):
     language: str = Field(primary_key=True, description="Programming language")
     library: str = Field(primary_key=True, description="Library / framework")
     docs_url: Optional[str] = Field(default=None, description="Docs URL")
+    description: Optional[str] = Field(default=None, description="Framework/library description")
 
     # Relationships
     features: List["FrameworkFeature"] = Relationship(

--- a/unoplat-code-confluence-commons/uv.lock
+++ b/unoplat-code-confluence-commons/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
### **User description**
The changes add a new `description` field to the `FrameworkModel` class in the `unoplat_code_confluence_commons` module. This field allows for a textual description of the framework or library to be stored, providing more context and information about the resource.

Additionally, the version of the `unoplat-code-confluence-commons` package is updated from `0.25.0` to `0.26.0` to reflect the new feature addition.


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional `description` field to Framework model

- Enable storing textual descriptions for frameworks/libraries

- Provide additional context for framework resources


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Framework Model"] --> B["Add description field"]
  B --> C["Enhanced framework metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>framework_models.py</strong><dd><code>Add description field to Framework model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/framework_models.py

<ul><li>Add optional <code>description</code> field to Framework SQLModel class<br> <li> Field allows storing textual descriptions of frameworks/libraries<br> <li> Provides additional metadata context for framework resources</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/739/files#diff-62f21a651218dc25a44c9c79473a6ada142688c03d554222bda503c0199d15db">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

