### PR TITLE
fix(code-confluence-flow-bridge): Fix single edge for similar feature to file relationships in graph

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py
@@ -781,8 +781,7 @@ class GenericCodebaseParser:
                         // WITH is required between MERGE (write) and MATCH (read) clauses
                         WITH fw, feat
                         MATCH (f:CodeConfluenceFile {file_path: $file_path})
-                        MERGE (f)-[r:USES_FEATURE]->(feat)
-                        SET r.start_line = $start_line, r.end_line = $end_line
+                        MERGE (f)-[r:USES_FEATURE {start_line: $start_line, end_line: $end_line, match_text: $match_text}]->(feat)
                         
                         RETURN fw, feat, f
                         """
@@ -799,6 +798,7 @@ class GenericCodebaseParser:
                                     "file_path": unoplat_file.file_path,
                                     "start_line": det.start_line,
                                     "end_line": det.end_line,
+                                    "match_text": getattr(det, "match_text", ""),
                                 },
                             )
                         )

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.50.0"
+version = "0.50.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
### **User description**
Update the `MERGE` statement in the `generic_codebase_parser.py` file
to include the `match_text` property in the relationship between
`CodeConfluenceFile` and `Feature` nodes.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Neo4j MERGE statement to include `match_text` property

- Prevent duplicate relationships between CodeConfluenceFile and Feature nodes

- Add missing `match_text` parameter to query execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CodeConfluenceFile"] -- "USES_FEATURE with match_text" --> B["Feature"]
  C["Query Parameters"] -- "includes match_text" --> D["Neo4j MERGE"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generic_codebase_parser.py</strong><dd><code>Fix Neo4j relationship creation with match_text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/generic_codebase_parser.py

<ul><li>Modified MERGE statement to include <code>match_text</code> in relationship <br>properties<br> <li> Added <code>match_text</code> parameter to query execution parameters<br> <li> Removed separate SET clause for relationship properties</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/754/files#diff-d647986e19cf71de4c0f762a829fe38402b2a106b126324cbb7992ff1d4c7cee">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

