### PR TITLE
chore(yak): update request models with new names

### DIFF
--- a/yak/yaak.rq_DwTkeJP8FJ.yaml
+++ b/yak/yaak.rq_DwTkeJP8FJ.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_DwTkeJP8FJ
 createdAt: 2025-06-06T04:50:08.587406
-updatedAt: 2025-08-28T04:51:39.111702
+updatedAt: 2025-08-30T05:57:47.230805
 workspaceId: wk_KULjx4bEa8
 folderId: fl_RfTzTxKasf
 authentication: {}
@@ -20,7 +20,7 @@ headers:
   value: ''
   id: k245dJt0Rn
 method: POST
-name: ingest-token
+name: jay-ingest-token
 sortPriority: 0.0
 url: http://127.0.0.1:8000/ingest-token
 urlParameters: []

--- a/yak/yaak.rq_zcJSFbvhRK.yaml
+++ b/yak/yaak.rq_zcJSFbvhRK.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_zcJSFbvhRK
 createdAt: 2025-08-26T06:34:22.722423
-updatedAt: 2025-08-28T04:53:21.854117
+updatedAt: 2025-08-30T05:57:42.028089
 workspaceId: wk_KULjx4bEa8
 folderId: fl_jtBaK7a5pU
 authentication: {}
@@ -32,7 +32,7 @@ headers:
   value: ''
   id: sQHXIdUvn2
 method: PUT
-name: set_model-huggingface-kimi
+name: jay-set_model-huggingface-kimi
 sortPriority: -0.0002
 url: http://127.0.0.1:8001/v1/config
 urlParameters: []


### PR DESCRIPTION
Update the `name` field for two HTTP request models to include the
prefix "jay-". This change is to differentiate these requests from
others in the system and make them more easily identifiable.