### PR TITLE
cjpre: Disable test execution and coverage reporting

### DIFF
--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -196,18 +196,18 @@ jobs:
           PACKAGE_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'].replace('-', '_'))")
           echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
         
-      - name: Install dependencies and run tests
-        working-directory: unoplat-code-confluence-query-engine
-        env:
-          GITHUB_PAT_TOKEN: ${{ github.token }} 
-        run: |
-          uv sync --group test
-          uv run --group test pytest --cov=src/${{ steps.package.outputs.name }} --cov-report=html:coverage_reports --cov-report=xml:coverage.xml --cov-report=term-missing tests/ -v
+      # - name: Install dependencies and run tests
+      #   working-directory: unoplat-code-confluence-query-engine
+      #   env:
+      #     GITHUB_PAT_TOKEN: ${{ github.token }} 
+      #   run: |
+      #     uv sync --group test
+      #     uv run --group test pytest --cov=src/${{ steps.package.outputs.name }} --cov-report=html:coverage_reports --cov-report=xml:coverage.xml --cov-report=term-missing tests/ -v
 
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports-query-engine
-          path: |
-            unoplat-code-confluence-query-engine/coverage_reports/
-          retention-days: 7
+      # - name: Upload coverage reports
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: coverage-reports-query-engine
+      #     path: |
+      #       unoplat-code-confluence-query-engine/coverage_reports/
+      #     retention-days: 7


### PR DESCRIPTION
### **User description**
Disables the test execution and coverage reporting steps in the
Python build workflow. This change is made to temporarily disable
these steps while investigating issues with the test suite and
coverage reporting.


___

### **PR Type**
Other


___

### **Description**
- Temporarily disable test execution and coverage reporting

- Comment out pytest and coverage upload steps

- Maintain workflow structure for future re-enabling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Python Build Workflow"] --> B["Package Name Extraction"]
  B --> C["Test Execution (Disabled)"]
  B --> D["Coverage Upload (Disabled)"]
  C -.-> E["pytest with coverage"]
  D -.-> F["Upload artifacts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_build.yaml</strong><dd><code>Disable test and coverage steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python_build.yaml

<ul><li>Comment out test execution step with <code>pytest</code> and coverage reporting<br> <li> Comment out coverage reports upload to artifacts<br> <li> Preserve workflow structure by commenting instead of removing</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/789/files#diff-acffa834ca92a0147495c1b31c0f6fbe52107d39165a10e37fcd2f4357f4ad31">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

