### PR TITLE
feat(github): add codebase metadata API endpoint

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/github/github_repo.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/github/github_repo.py
@@ -4,6 +4,9 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 from unoplat_code_confluence_commons.configuration_models import CodebaseConfig
+from unoplat_code_confluence_commons.programming_language_metadata import (
+    ProgrammingLanguageMetadata,
+)
 
 
 class GitHubOwner(BaseModel):
@@ -229,5 +232,21 @@ class RefreshRepositoryResponse(BaseModel):
     repository_owner_name: str = Field(description="The name of the repository owner")
     workflow_id: str = Field(description="The ID of the started workflow")
     run_id: str = Field(description="The run ID of the started workflow")
-    
+
+
+class CodebaseMetadataResponse(BaseModel):
+    """Response model for individual codebase metadata."""
+    codebase_folder: str = Field(description="Path to codebase folder relative to repo root")
+    programming_language_metadata: ProgrammingLanguageMetadata = Field(
+        description="Language-specific metadata for this codebase"
+    )
+
+
+class CodebaseMetadataListResponse(BaseModel):
+    """Response model containing list of codebase metadata for a repository."""
+    repository_name: str = Field(description="The name of the repository")
+    repository_owner_name: str = Field(description="The name of the repository owner")
+    codebases: List[CodebaseMetadataResponse] = Field(
+        description="List of codebase configurations with metadata"
+    )
     

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.50.1"
+version = "0.50.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
### **User description**
This change adds a new API endpoint `/codebase-metadata` to the Code Confluence Flow Bridge service. This endpoint allows users to retrieve the codebase folder paths and programming language metadata for a given repository.

The changes include:

- Adding new Pydantic models `CodebaseMetadataResponse` and `CodebaseMetadataListResponse` to represent the response data.
- Implementing a new `get_codebase_metadata` function that fetches the repository data from the database and maps it to the response models.
- Updating the `unoplat.lock` file to reflect the version bump to `0.50.2`.

This feature will enable users to easily access the codebase metadata for a repository, which is useful for various use cases such as analysis, reporting, and integration with other systems.


___

### **PR Type**
Enhancement


___

### **Description**
- Add new `/codebase-metadata` API endpoint for repository metadata retrieval

- Create Pydantic models for codebase metadata response structure

- Implement database query with codebase configuration mapping

- Enable access to folder paths and programming language metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Request"] --> B["get_codebase_metadata endpoint"]
  B --> C["Database Query"]
  C --> D["Repository with configs"]
  D --> E["Map to Response Models"]
  E --> F["CodebaseMetadataListResponse"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Implement codebase metadata API endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/main.py

<ul><li>Add new <code>/codebase-metadata</code> GET endpoint with query parameters<br> <li> Implement <code>get_codebase_metadata</code> function with database querying<br> <li> Add error handling for repository not found and processing errors<br> <li> Import new response model classes for codebase metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/804/files#diff-7b3c88e488de42696126730d1996bc91a65043a80eeffd518828a64898c78aaf">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github_repo.py</strong><dd><code>Add Pydantic models for codebase metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/models/github/github_repo.py

<ul><li>Add <code>CodebaseMetadataResponse</code> model for individual codebase data<br> <li> Add <code>CodebaseMetadataListResponse</code> model for repository metadata list<br> <li> Import <code>ProgrammingLanguageMetadata</code> from commons package<br> <li> Define response structure with folder paths and language metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/804/files#diff-95bd85c7e497e34a5b5a8668830f49d561194dc19debda832eccc049d2123fe0">+20/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

