### PR TITLE
fix(unoplat-code-confluence-query-engine): Bump version to 0.9.0

### DIFF
--- a/unoplat-code-confluence-query-engine/local-dependencies-docker-compose.yml
+++ b/unoplat-code-confluence-query-engine/local-dependencies-docker-compose.yml
@@ -134,14 +134,14 @@ services:
       retries: 5
 
   code-confluence-flow-bridge:
-    image: ghcr.io/unoplat/code-confluence-flow-bridge:0.50.2
+    image: ghcr.io/unoplat/code-confluence-flow-bridge:0.51.0
     environment:
       - NEO4J_HOST=neo4j
       - NEO4J_PORT=7687
       - NEO4J_USERNAME=neo4j
       - NEO4J_PASSWORD=password
       - TEMPORAL_SERVER_ADDRESS=temporal:7233
-      - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8001
+      - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8001,http://localhost:5173
       - DB_HOST=postgresql
       - TEMPORAL_DEBUG=true
       - LOG_LEVEL=DEBUG

--- a/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py
+++ b/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py
@@ -388,7 +388,7 @@ async def generate_sse_events(
         for codebase_name, aggregator in aggregators.items():
             final_model = aggregator.to_final_model()
             # Exclude optional fields that are None to avoid nulls in SSE payload
-            final_payload["codebases"][codebase_name] = final_model.model_dump(exclude_none=True)  # type: ignore
+            final_payload["codebases"][codebase_name] = final_model.model_dump_json(exclude_none=True)  # type: ignore
         
         # Emit final repository-level event
         final_event = {

--- a/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py
+++ b/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py
@@ -387,7 +387,8 @@ async def generate_sse_events(
         
         for codebase_name, aggregator in aggregators.items():
             final_model = aggregator.to_final_model()
-            final_payload["codebases"][codebase_name] = json.loads(final_model.model_dump_json()) #type: ignore
+            # Exclude optional fields that are None to avoid nulls in SSE payload
+            final_payload["codebases"][codebase_name] = final_model.model_dump(exclude_none=True)  # type: ignore
         
         # Emit final repository-level event
         final_event = {

--- a/unoplat-code-confluence-query-engine/uv.lock
+++ b/unoplat-code-confluence-query-engine/uv.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "unoplat-code-confluence-query-engine"
-version = "0.8.0"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/yak/yaak.rq_UvGqPcvBGu.yaml
+++ b/yak/yaak.rq_UvGqPcvBGu.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_UvGqPcvBGu
 createdAt: 2025-08-07T04:56:27.785874
-updatedAt: 2025-09-13T05:45:00.077364
+updatedAt: 2025-09-13T12:17:36.613043
 workspaceId: wk_KULjx4bEa8
 folderId: fl_zukJtBcFCC
 authentication: {}
@@ -12,7 +12,7 @@ bodyType: null
 description: ''
 headers: []
 method: GET
-name: test-agent-pc-dw-bl-xai-grok-code-fast-1-or
+name: test-agent-pc-dw-bl-xai-grok-code-fast-1-or-all-codebases
 sortPriority: 4000.0
 url: http://localhost:8001/v1/codebase-agent-rules
 urlParameters:


### PR DESCRIPTION
### **User description**
Increase the version of the `unoplat-code-confluence-query-engine` package
from 0.8.0 to 0.9.0 to reflect the changes made in this commit.

feat(yak/yaak.rq_UvGqPcvBGu.yaml): Update request name

Change the name of the HTTP request from "test-agent-pc-dw-bl-xai-grok-code-fast-1-or"
to "test-agent-pc-dw-bl-xai-grok-code-fast-1-or-all-codebases" to better
describe the purpose of the request.

feat(local-dependencies-docker-compose.yml): Bump code-confluence-flow-bridge to 0.51.0

Update the version of the `code-confluence-flow-bridge` Docker image from
0.50.2 to 0.51.0 to incorporate the latest changes and improvements.
Also, add a new allowed origin for the `http://localhost:5173` URL.

fix(unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py): Exclude optional fields with None values

Modify the code to exclude optional fields with `None` values when
dumping the final model to the SSE payload. This ensures that the
payload does not contain unnecessary `null` values.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix null value exclusion in SSE payload generation

- Update Docker image version to 0.51.0

- Add localhost:5173 to allowed origins

- Rename HTTP request for better clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SSE Payload Generation"] --> B["Exclude None Values"]
  C["Docker Compose"] --> D["Update Image Version"]
  C --> E["Add Allowed Origin"]
  F["HTTP Request"] --> G["Update Request Name"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codebase_agent_rules.py</strong><dd><code>Exclude None values from SSE payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py

<ul><li>Replace <code>json.loads(final_model.model_dump_json())</code> with <br><code>final_model.model_dump(exclude_none=True)</code><br> <li> Add comment explaining the purpose of excluding None values<br> <li> Prevent null values from appearing in SSE payload</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/809/files#diff-dcfa78f640984fad2eed5f1e8e941ddbf1bd1dabe484643fbbd59a69033c7bb6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local-dependencies-docker-compose.yml</strong><dd><code>Update Docker image and add allowed origin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-query-engine/local-dependencies-docker-compose.yml

<ul><li>Update code-confluence-flow-bridge image from 0.50.2 to 0.51.0<br> <li> Add <code>http://localhost:5173</code> to ALLOWED_ORIGINS environment variable</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/809/files#diff-5f74e8d091af6e8860852b1b35633c682653dc9f2fb91fb9561c8535d78c5038">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>yaak.rq_UvGqPcvBGu.yaml</strong><dd><code>Rename HTTP request for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

yak/yaak.rq_UvGqPcvBGu.yaml

<ul><li>Change request name from "test-agent-pc-dw-bl-xai-grok-code-fast-1-or" <br>to "test-agent-pc-dw-bl-xai-grok-code-fast-1-or-all-codebases"<br> <li> Update timestamp in updatedAt field</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/809/files#diff-c8ad220a4faca7d583a7006a5ccaa86d0f88f476bfd3a6f1adfc0fb6124aaa16">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

