### PR TITLE
feat(config): improve config hot reload handling and introduce mock sse endpoint for ui testing as not all providers support prompt caching

### DIFF
--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -165,6 +165,31 @@ services:
       - temporal-network
     stdin_open: true
     tty: true
+  unoplat-code-confluence-query-engine:
+    # container_name: unoplat-code-confluence-query-engine
+    build:
+      context: ./unoplat-code-confluence-query-engine
+      dockerfile: Dockerfile
+    environment:
+      - NEO4J_HOST=neo4j
+      - NEO4J_PORT=7687
+      - NEO4J_USERNAME=neo4j
+      - NEO4J_PASSWORD=password
+      - DB_HOST=postgresql
+      - DB_PORT=5432
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=code_confluence
+    ports:
+      - "8001:8000"
+    networks:
+      - temporal-network
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+
   unoplat-code-confluence-frontend:
     # container_name: unoplat-code-confluence-frontend
     depends_on:

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -155,6 +155,28 @@ services:
       - temporal-network
     stdin_open: true
     tty: true
+  unoplat-code-confluence-query-engine:
+    image: ghcr.io/unoplat/unoplat-code-confluence-query-engine:0.1.0
+    environment:
+      - NEO4J_HOST=neo4j
+      - NEO4J_PORT=7687
+      - NEO4J_USERNAME=neo4j
+      - NEO4J_PASSWORD=password
+      - DB_HOST=postgresql
+      - DB_PORT=5432
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=code_confluence
+    ports:
+      - "8001:8000"
+    networks:
+      - temporal-network
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+
   unoplat-code-confluence-frontend:
     image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.25.0
     environment:

--- a/unoplat-code-confluence-query-engine/Taskfile.yml
+++ b/unoplat-code-confluence-query-engine/Taskfile.yml
@@ -54,6 +54,12 @@ tasks:
       - task: start-dependencies
       - task: run-dev
 
+  mock-sse:
+    desc: Run mock SSE server (replays docs/sse-agent-results.txt) on port 8002
+    dir: experiments
+    cmds:
+      - uv run fastapi dev mock_sse_server.py --port 8002
+
   test:
     desc: Run tests with coverage
     dir: .

--- a/unoplat-code-confluence-query-engine/experiments/mock_sse_server.py
+++ b/unoplat-code-confluence-query-engine/experiments/mock_sse_server.py
@@ -1,0 +1,161 @@
+"""Mock SSE server that replays events from docs/sse-agent-results.txt.
+
+This standalone FastAPI app exposes an endpoint compatible with the real
+`/v1/codebase-agent-rules` route and streams Server-Sent Events in the exact
+order captured in the reference log file. Useful for UI/dev testing without
+running the full agent pipeline or external services.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncGenerator, Dict, List, Optional
+
+from fastapi import FastAPI, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from loguru import logger
+from sse_starlette.sse import EventSourceResponse
+
+APP_TITLE: str = "Mock Codebase Agent Rules SSE Server"
+DEFAULT_DELAY_SECONDS: float = 0.05
+
+# Resolve repository root and reference SSE log file
+REPO_ROOT: Path = Path(__file__).resolve().parents[1]
+SSE_LOG_PATH: Path = REPO_ROOT / "docs" / "sse-agent-results.txt"
+
+
+# In-memory cache of parsed SSE events
+LOADED_EVENTS: List[Dict[str, str]] = []
+
+
+def parse_sse_log_file(file_path: Path) -> List[Dict[str, str]]:
+    """Parse a newline-delimited SSE capture file into event dicts.
+
+    The expected format mirrors what `curl -N` would show:
+      id: 1\n
+      event: repo:agent:event_type\n
+      data: {"json": "object"}\n
+      \n
+    - Blank line separates events
+    - Lines starting with "::" are treated as comments/keepalive pings and skipped
+
+    Returns a list of dicts each containing keys: "id", "event", "data".
+    Data is preserved as a raw JSON string to match the real endpoint behavior.
+    """
+    events: List[Dict[str, str]] = []
+    current: Dict[str, str] = {}
+
+    try:
+        raw_text: str = file_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        logger.error("SSE log file not found at {}", file_path)
+        raise exc
+
+    for raw_line in raw_text.splitlines():
+        line: str = raw_line.strip()
+
+        if not line:
+            if "event" in current and "data" in current:
+                if "id" not in current:
+                    current["id"] = str(len(events))
+                events.append(current)
+            current = {}
+            continue
+
+        if line.startswith("::"):
+            # Skip comment/ping lines
+            continue
+
+        if line.startswith("id:"):
+            current["id"] = line.partition("id:")[2].strip()
+            continue
+
+        if line.startswith("event:"):
+            current["event"] = line.partition("event:")[2].strip()
+            continue
+
+        if line.startswith("data:"):
+            # Preserve raw JSON string as-is
+            current["data"] = line.partition("data:")[2].strip()
+            continue
+
+    # Finalize trailing event if file doesn't end with a blank line
+    if current and "event" in current and "data" in current:
+        if "id" not in current:
+            current["id"] = str(len(events))
+        events.append(current)
+
+    return events
+
+
+async def stream_mock_events(
+    request: Request, *, delay_seconds: float
+) -> AsyncGenerator[Dict[str, str], None]:
+    """Yield parsed SSE events to the client with an optional delay between them.
+
+    The yielded dicts follow sse-starlette's expected structure: keys "id",
+    "event", and "data". `data` remains a JSON string, matching the real
+    endpoint which serializes payloads prior to emission.
+    """
+    for event in LOADED_EVENTS:
+        if await request.is_disconnected():
+            logger.info("Mock SSE client disconnected early")
+            break
+
+        yield event
+
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
+
+
+app: FastAPI = FastAPI(title=APP_TITLE)
+
+# Add CORS middleware to allow cross-origin requests (matches main.py configuration)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Configure appropriately for production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+    expose_headers=["*"],  # Important for SSE headers
+)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    """Load and cache SSE events from the reference file on startup."""
+    global LOADED_EVENTS
+    LOADED_EVENTS = parse_sse_log_file(SSE_LOG_PATH)
+    logger.info("Loaded {} mock SSE events from {}", len(LOADED_EVENTS), SSE_LOG_PATH)
+
+
+@app.get("/v1/codebase-agent-rules")
+async def get_mock_codebase_agent_rules(
+    request: Request,
+    owner_name: str = Query(..., description="Repository owner name"),
+    repo_name: str = Query(..., description="Repository name"),
+    delay_seconds: Optional[float] = Query(
+        default=DEFAULT_DELAY_SECONDS,
+        ge=0.0,
+        le=2.0,
+        description="Artificial delay between events to simulate streaming",
+    ),
+) -> EventSourceResponse:
+    """Stream mock SSE events in the same order as the captured session.
+
+    Query params are accepted for API compatibility, but do not affect the
+    mocked stream content.
+    """
+    headers: Dict[str, str] = {
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
+    }
+    return EventSourceResponse(
+        stream_mock_events(request, delay_seconds=delay_seconds or 0.0),
+        ping=10,
+        headers=headers,
+    )
+
+

--- a/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/models/agent_md_output.py
+++ b/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/models/agent_md_output.py
@@ -329,7 +329,7 @@ class AgentMdOutput(BaseModel):
         ..., description="Critical business logic domains"
     )
     #TODO: remove optional when ready
-    app_interaces: Optional[Interfaces] = Field(
+    app_interfaces: Optional[Interfaces] = Field(
         default=None, description="Inbound or/and outboundInteraces used in the codebase"
     )
 

--- a/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/services/config_hot_reload.py
+++ b/unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/services/config_hot_reload.py
@@ -27,6 +27,7 @@ from unoplat_code_confluence_query_engine.services.model_factory import ModelFac
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+
     from unoplat_code_confluence_query_engine.config.settings import EnvironmentSettings
 
 # Global state for tracking configuration changes and model instances
@@ -173,7 +174,9 @@ async def get_current_model(settings: Optional["EnvironmentSettings"] = None) ->
         
         # Use provided settings or fall back to creating new instance
         if settings is None:
-            from unoplat_code_confluence_query_engine.config.settings import EnvironmentSettings
+            from unoplat_code_confluence_query_engine.config.settings import (
+                EnvironmentSettings,
+            )
             settings = EnvironmentSettings()
         
         _current_model, _current_model_settings = await _model_factory.build(config, settings)

--- a/unoplat-code-confluence-query-engine/uv.lock
+++ b/unoplat-code-confluence-query-engine/uv.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "unoplat-code-confluence-query-engine"
-version = "0.9.0"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/yak/yaak.rq_ZCT8QECJLF.yaml
+++ b/yak/yaak.rq_ZCT8QECJLF.yaml
@@ -1,0 +1,30 @@
+type: http_request
+model: http_request
+id: rq_ZCT8QECJLF
+createdAt: 2025-09-15T11:23:47.226515
+updatedAt: 2025-09-15T11:24:59.927451
+workspaceId: wk_KULjx4bEa8
+folderId: fl_zukJtBcFCC
+authentication: {}
+authenticationType: null
+body: {}
+bodyType: null
+description: ''
+headers: []
+method: GET
+name: mock-test-agent-pc-dw-bl-xai-grok-code-fast-1-or-all-codebases
+sortPriority: 4000.001
+url: http://localhost:8002/v1/codebase-agent-rules
+urlParameters:
+- enabled: true
+  name: owner_name
+  value: unoplat
+  id: XVEctDb8wq
+- enabled: true
+  name: repo_name
+  value: unoplat-code-confluence
+  id: 3apksU6Xei
+- enabled: true
+  name: ''
+  value: ''
+  id: zfTZmKzX25


### PR DESCRIPTION
The changes in this commit improve the handling of configuration hot reloading in the `config_hot_reload.py` module. Specifically:

- The `EnvironmentSettings` import is now wrapped in a conditional block to avoid circular imports.
- The `settings` parameter in the `_model_factory.build()` call is now properly handled, falling back to creating a new `EnvironmentSettings` instance if `settings` is `None`.

These changes help ensure the configuration hot reload functionality works as expected and avoids potential issues with circular imports.

feat(experiments): add mock SSE server

This commit introduces a new standalone FastAPI application in the `experiments` directory that provides a mock Server-Sent Events (SSE) server. The purpose of this mock server is to replay events from a captured log file (`docs/sse-agent-results.txt`) to enable UI/development testing without running the full agent pipeline or external services.

The key features of the mock SSE server include:

- Parsing the reference SSE log file and caching the events in memory on startup.
- Exposing an API endpoint at `/v1/codebase-agent-rules` that streams the cached events to clients.
- Allowing an optional delay between event emissions to simulate a real-time streaming experience.
- Adding CORS middleware to enable cross-origin requests, matching the main application configuration.

This mock server provides a convenient way to test the UI and other components that consume the codebase agent rules SSE stream without the need for a fully running system.

fix(models): correct typo in app_interfaces field

This commit fixes a minor typo in the `AgentMDOutput` model, where the `app_interaces` field was misspelled as `app_interaces`. The correct field name is now `app_interfaces`.

This change ensures the model definition matches the expected field name and avoids potential issues with data serialization/deserialization.

chore(docker): add unoplat-code-confluence-query-engine service

This commit adds a new service definition for the `unoplat-code-confluence-query-engine` application in the `local-docker-compose.yml` file. The new service includes the following configuration:

- Builds the application image using the Dockerfile in the `unoplat-code-confluence-query-engine` directory.
- Sets the necessary environment variables for connecting to the PostgreSQL and Neo4j databases.
- Exposes the application on port 8001.
- Depends on the `postgresql` and `neo4j` services, ensuring they are healthy before starting the application.

This change makes it easier to run the full application stack locally using Docker Compose, including the query engine service.

refactor(codebase-agent-rules): improve SSE event naming

The changes in this commit improve the naming of the Server-Sent Events (SSE) emitted by the `/v1/codebase-agent-rules` endpoint. Specifically:

- A new `build_repo_agent_event_name()` function is introduced to construct a namespaced event name in the format `{repository_qualified_name}:{agent_name}:{event_type}`.
- This namespaced event name is used when emitting the initial "status" event and the final "aggregated_final_summary_agent" event.

Using the repository-qualified name as the first part of the event name ensures uniqueness across concurrent SSE connections for different repositories, improving the ability to track and identify events.