### PR TITLE
feat(repo_models): Add RepositoryAgentMdSnapshot model

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
@@ -37,6 +37,9 @@ from unoplat_code_confluence_commons.base_models import (
     # Structural signature models
     VariableInfo,
 )
+from unoplat_code_confluence_commons.repo_models import (
+    RepositoryAgentMdSnapshot,
+)
 from unoplat_code_confluence_commons.graph_models import (
     BaseNode,
     CodeConfluenceCodebase,
@@ -94,6 +97,7 @@ __all__ = [
     'ProgrammingLanguageMetadata',
     'ProgrammingLanguage',
     'PackageManagerType',
+    'RepositoryAgentMdSnapshot',
     # Credentials model
     'Credentials',
     # Flags model

--- a/unoplat-code-confluence-commons/uv.lock
+++ b/unoplat-code-confluence-commons/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This change adds a new SQLModel class `RepositoryAgentMdSnapshot` to the `repo_models.py` file. This model represents a table in the `code_confluence` schema that stores the agent metadata snapshot for a given repository.

The new model includes the following fields:

- `repository_name`: The name of the repository
- `repository_owner_name`: The name of the repository owner
- `agent_md_output`: A JSONB field that stores the complete final payload from the `generate_sse_events()` function, containing per-codebase agent data
- `created_at`: The timestamp when the row was first inserted
- `modified_at`: The timestamp when the latest overwrite occurred

The model also includes a one-to-one relationship with the `Repository` model, allowing easy access to the repository information associated with the agent metadata snapshot.

This change is important as it provides a way to store and retrieve the agent metadata for a given repository, which is crucial for various analysis and reporting tasks within the code confluence system.