### PR TITLE
feat(agent_md_output): upgrade unoplat-code-confluence-commons to v0.28.0 and endpoint for retrieval

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/pyproject.toml
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 [tool.uv.sources]
 #NOTE: use it for local development to instantly see changes in the schema and its impact
 #unoplat-code-confluence-commons = { path = "../../unoplat-code-confluence-commons" }
-unoplat-code-confluence-commons = { git = "https://github.com/unoplat/unoplat-code-confluence.git", subdirectory = "unoplat-code-confluence-commons", rev = "unoplat-code-confluence-commons-v0.27.1" }
+unoplat-code-confluence-commons = { git = "https://github.com/unoplat/unoplat-code-confluence.git", subdirectory = "unoplat-code-confluence-commons", rev = "unoplat-code-confluence-commons-v0.28.0" }
 
 
 [tool.uv]

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.50.2"
+version = "0.51.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },
@@ -356,7 +356,7 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "tree-sitter-language-pack", specifier = ">=0.8.0" },
     { name = "typing-extensions", specifier = ">=4.11" },
-    { name = "unoplat-code-confluence-commons", git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.27.1" },
+    { name = "unoplat-code-confluence-commons", git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.28.0" },
     { name = "validate-pyproject", extras = ["all"], specifier = ">=0.23" },
 ]
 
@@ -2059,8 +2059,8 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.27.1"
-source = { git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.27.1#0bd3e7f7037af29e907f472176068e5c420a85f5" }
+version = "0.28.0"
+source = { git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.28.0#fcced1ef74f30ef8523645bdfaeef9addacef420" }
 dependencies = [
     { name = "cryptography" },
     { name = "neomodel" },

--- a/unoplat-code-confluence-query-engine/pyproject.toml
+++ b/unoplat-code-confluence-query-engine/pyproject.toml
@@ -51,4 +51,6 @@ markers = [
 ]
 
 [tool.uv.sources]
-unoplat-code-confluence-commons = { git = "https://github.com/unoplat/unoplat-code-confluence.git", subdirectory = "unoplat-code-confluence-commons", rev = "unoplat-code-confluence-commons-v0.27.1" }
+#NOTE: use it for local development to instantly see changes in the schema and its impact
+#unoplat-code-confluence-commons = { path = "../unoplat-code-confluence-commons" }
+unoplat-code-confluence-commons = { git = "https://github.com/unoplat/unoplat-code-confluence.git", subdirectory = "unoplat-code-confluence-commons", rev = "unoplat-code-confluence-commons-v0.28.0" }

--- a/unoplat-code-confluence-query-engine/uv.lock
+++ b/unoplat-code-confluence-query-engine/uv.lock
@@ -2294,8 +2294,8 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.27.1"
-source = { git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.27.1#0bd3e7f7037af29e907f472176068e5c420a85f5" }
+version = "0.28.0"
+source = { git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.28.0#fcced1ef74f30ef8523645bdfaeef9addacef420" }
 dependencies = [
     { name = "cryptography" },
     { name = "neomodel" },
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "unoplat-code-confluence-query-engine"
-version = "0.10.0"
+version = "0.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2365,7 +2365,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
     { name = "sse-starlette", specifier = ">=3.0.0" },
-    { name = "unoplat-code-confluence-commons", git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.27.1" },
+    { name = "unoplat-code-confluence-commons", git = "https://github.com/unoplat/unoplat-code-confluence.git?subdirectory=unoplat-code-confluence-commons&rev=unoplat-code-confluence-commons-v0.28.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
### **User description**
This change upgrades the dependency on the unoplat-code-confluence-commons
library from version 0.27.1 to 0.28.0 across the code-confluence-flow-bridge
and code-confluence-query-engine projects. The upgrade includes the following
key changes:

- Bumps the version of the unoplat-code-confluence-commons dependency in the
  uv.lock files for both projects.
- Updates the git revision reference in the pyproject.toml files to point to
  the new 0.28.0 tag.
- Adds a new endpoint /repository-agent-snapshot to the query-engine API that
  allows retrieving the latest agent-generated metadata snapshot for a
  repository.

The upgrade to the unoplat-code-confluence-commons library is necessary to
take advantage of the new agent snapshot persistence and retrieval
functionality, which will be used to improve the user experience and
reliability of the codebase agent rules execution.


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade unoplat-code-confluence-commons dependency to v0.28.0

- Add repository agent snapshot persistence functionality

- Implement new endpoint for retrieving agent metadata

- Enhance SSE event handling with database storage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SSE Agent Rules"] --> B["Generate Final Payload"]
  B --> C["Persist to PostgreSQL"]
  C --> D["RepositoryAgentMdSnapshot Table"]
  E["New GET Endpoint"] --> F["Retrieve Snapshot"]
  F --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codebase_agent_rules.py</strong><dd><code>Add agent snapshot persistence and retrieval endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-query-engine/src/unoplat_code_confluence_query_engine/api/v1/endpoints/codebase_agent_rules.py

<ul><li>Add database imports for PostgreSQL operations<br> <li> Implement agent snapshot persistence with upsert logic<br> <li> Add new <code>/repository-agent-snapshot</code> GET endpoint<br> <li> Enhance error handling and logging for persistence</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/825/files#diff-dcfa78f640984fad2eed5f1e8e941ddbf1bd1dabe484643fbbd59a69033c7bb6">+79/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Upgrade commons dependency to v0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/pyproject.toml

<ul><li>Update unoplat-code-confluence-commons dependency from v0.27.1 to <br>v0.28.0</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/825/files#diff-b9ff793e6fa07f126e8b12de38d04175c184ea292ad2de1f00ab830834459722">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Upgrade commons dependency to v0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-query-engine/pyproject.toml

<ul><li>Update unoplat-code-confluence-commons dependency from v0.27.1 to <br>v0.28.0<br> <li> Add commented local development path option</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/825/files#diff-2b2981108882da746ac4a2e43f0fa4ac4065358051d7a2abf511968ef1f304d6">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

