### PR TITLE
feat(repo-models): Add RepoAgentSnapshotStatus enum and update RepositoryAgentMdSnapshot

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
@@ -38,6 +38,7 @@ from unoplat_code_confluence_commons.base_models import (
     VariableInfo,
 )
 from unoplat_code_confluence_commons.repo_models import (
+    RepoAgentSnapshotStatus,
     RepositoryAgentMdSnapshot,
 )
 from unoplat_code_confluence_commons.graph_models import (
@@ -98,6 +99,7 @@ __all__ = [
     'ProgrammingLanguage',
     'PackageManagerType',
     'RepositoryAgentMdSnapshot',
+    'RepoAgentSnapshotStatus',
     # Credentials model
     'Credentials',
     # Flags model

--- a/unoplat-code-confluence-commons/uv.lock
+++ b/unoplat-code-confluence-commons/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.27.1"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
### **User description**
The changes introduce a new `RepoAgentSnapshotStatus` enum to represent the lifecycle status of a repository agent markdown snapshot. Additionally, the `RepositoryAgentMdSnapshot` model is updated to include new fields for `events`, `agent_md_output`, and `status`.

The `events` field captures the events and progress during the agent execution, while the `agent_md_output` field stores the complete final payload from the agent execution. The `status` field tracks the lifecycle status of the snapshot, which can be `RUNNING`, `COMPLETED`, or `ERROR`.

These changes are necessary to improve the tracking and management of repository agent markdown snapshots, providing more detailed information about the execution process and the final output.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `RepoAgentSnapshotStatus` enum with RUNNING, COMPLETED, ERROR states

- Update `RepositoryAgentMdSnapshot` model with new tracking fields

- Add `events` field for capturing agent execution progress

- Add `status` field for lifecycle management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RepoAgentSnapshotStatus enum"] --> B["RepositoryAgentMdSnapshot model"]
  B --> C["events field"]
  B --> D["status field"]
  B --> E["agent_md_output field"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export new RepoAgentSnapshotStatus enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py

<ul><li>Add <code>RepoAgentSnapshotStatus</code> to imports and exports<br> <li> Update module's public API to include new enum</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/831/files#diff-2d6c5fd2e21027f0dc107ed1c4f30ee737aabbf48d7d0d9f461fb52d5c82eb15">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repo_models.py</strong><dd><code>Enhance RepositoryAgentMdSnapshot with status tracking</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py

<ul><li>Add <code>RepoAgentSnapshotStatus</code> enum with RUNNING, COMPLETED, ERROR values<br> <li> Add <code>events</code> JSONB field to capture agent execution progress<br> <li> Add <code>status</code> field with enum type and default RUNNING value<br> <li> Update <code>agent_md_output</code> field comment for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/831/files#diff-f2e444caa052dd965111a885baa0a293e85e3ae046e18f4410fe49f4485ce53d">+37/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

