### PR TITLE
fix(ci): add docker image matrix and check for images

### DIFF
--- a/.github/workflows/publish_release_management.yaml
+++ b/.github/workflows/publish_release_management.yaml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release_action_plan.outputs.releases_created }}
       matrix: ${{ steps.create-matrix.outputs.matrix }}   # noqa: unknown-context
+      has_docker_images: ${{ steps.create-matrix.outputs.has_docker_images }}
     steps:
     - name: Checkout our repository
       uses: actions/checkout@v2
@@ -61,8 +62,15 @@ jobs:
             return { path, image_name, version };
           }).filter(item => item !== null);
           
-          console.log("Final Docker Matrix:", includeArray);
-          core.setOutput('matrix', JSON.stringify({ include: includeArray }));
+          const hasDockerImages = includeArray.length > 0;
+          // Prevent empty matrix error by adding a sentinel if needed
+          const matrixObj = hasDockerImages
+            ? { include: includeArray }
+            : { include: [{ path: '__skip__', image_name: '__skip__', version: '0' }] };
+
+          console.log("Final Docker Matrix:", matrixObj.include);
+          core.setOutput('matrix', JSON.stringify(matrixObj));
+          core.setOutput('has_docker_images', hasDockerImages.toString());
 
   release-docker-image:
     name: Build and Push Docker Image
@@ -71,7 +79,7 @@ jobs:
     permissions: 
       contents: read
       packages: write
-    if: needs.main-pr-merge.outputs.release_created == 'true'
+    if: needs.main-pr-merge.outputs.release_created == 'true' && needs.main-pr-merge.outputs.has_docker_images == 'true'
     strategy:
       matrix: ${{ fromJson(needs.main-pr-merge.outputs.matrix) }}  # noqa: unknown-context
     steps:


### PR DESCRIPTION
### **User description**
The changes in this commit add the ability to create a Docker image matrix and check if there are any Docker images to build and push. This is done to ensure that the release-docker-image job only runs if there are Docker images to build and push.

The key changes are:

- Add a new output `has_docker_images` to the `main-pr-merge` job, which indicates whether there are any Docker images to build and push.
- Modify the `main-pr-merge` job to set the `matrix` output based on the presence of Docker images. If there are no images, a sentinel value is added to the matrix to prevent the `release-docker-image` job from failing due to an empty matrix.
- Update the `release-docker-image` job to only run if the `release_created` and `has_docker_images` outputs from the `main-pr-merge` job are both `true`.


___

### **PR Type**
Bug fix


___

### **Description**
- Add conditional check for Docker images in CI workflow

- Prevent empty matrix errors with sentinel value

- Skip Docker job when no images exist


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["main-pr-merge job"] --> B["Check for Docker images"]
  B --> C["Set has_docker_images output"]
  B --> D["Create matrix with sentinel if empty"]
  C --> E["release-docker-image job"]
  D --> E
  E --> F["Skip if no Docker images"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish_release_management.yaml</strong><dd><code>Add Docker image detection and conditional execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish_release_management.yaml

<ul><li>Add <code>has_docker_images</code> output to track Docker image presence<br> <li> Modify matrix creation to include sentinel value for empty cases<br> <li> Update job condition to check both release creation and Docker image <br>existence<br> <li> Prevent workflow failures when no Docker images are found</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/835/files#diff-9b07d83b74ab65bfc8626c6a12337256e2b98931797f7172358a1bef312afee4">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

