### PR TITLE
chore(ci): merge with dev branch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ This directory contains GitHub Actions workflows for the Unoplat Code Confluence
 
 ### Python Build (`python_build.yaml`)
 
-This workflow runs on pull requests to the `main` branch that include changes to Python projects:
+This workflow runs on pull requests to the `dev` branch that include changes to Python projects:
 - `unoplat-code-confluence-commons`
 - `unoplat-code-confluence-ingestion`
 
@@ -17,7 +17,7 @@ It performs the following tasks:
 
 ### Docusaurus Build (`docusaurus_build.yaml`)
 
-This workflow runs on pull requests to the `main` branch that include changes to the Docusaurus documentation site:
+This workflow runs on pull requests to the `dev` branch that include changes to the Docusaurus documentation site:
 - `code-confluence`
 
 It performs the following tasks:

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'code-confluence/**'
   pull_request:
     types: [closed]
     branches:
       - main
+      - dev
     paths:
       - 'code-confluence/**'
 

--- a/.github/workflows/docusaurus_build.yaml
+++ b/.github/workflows/docusaurus_build.yaml
@@ -10,6 +10,7 @@ on:
       - 'code-confluence/**'
     branches:
       - main
+      - dev
 
 jobs:
   test-docusaurus-build:

--- a/.github/workflows/frontend_version_test.yaml
+++ b/.github/workflows/frontend_version_test.yaml
@@ -6,7 +6,7 @@ on:
       - synchronize
       - reopened
     branches:
-      - main
+      - dev
     paths:
       - 'unoplat-code-confluence-frontend/**'
 

--- a/.github/workflows/publish_release_management.yaml
+++ b/.github/workflows/publish_release_management.yaml
@@ -1,13 +1,13 @@
-name: Merge with main branch
+name: Merge with dev branch
 
 on:
   pull_request:
     types: [closed]
     branches:
-      - main
+      - dev
 
 jobs:
-  main-pr-merge:
+  dev-pr-merge:
     if: github.event.pull_request.merged == true
     permissions: write-all
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout our repository
       uses: actions/checkout@v2
       with:
-        ref: main
+        ref: dev
 
     - name: Configure Git
       run: |
@@ -34,7 +34,7 @@ jobs:
         config-file: .github/configuration/release-please-config.json
         manifest-file: .github/configuration/release-please-manifest.json
         include-component-in-tag: true
-        target-branch: main
+        target-branch: dev
         
     - name: Create matrix for release    
       id: create-matrix
@@ -75,18 +75,18 @@ jobs:
   release-docker-image:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    needs: main-pr-merge
+    needs: dev-pr-merge
     permissions: 
       contents: read
       packages: write
-    if: needs.main-pr-merge.outputs.release_created == 'true' && needs.main-pr-merge.outputs.has_docker_images == 'true'
+    if: needs.dev-pr-merge.outputs.release_created == 'true' && needs.dev-pr-merge.outputs.has_docker_images == 'true'
     strategy:
-      matrix: ${{ fromJson(needs.main-pr-merge.outputs.matrix) }}  # noqa: unknown-context
+      matrix: ${{ fromJson(needs.dev-pr-merge.outputs.matrix) }}  # noqa: unknown-context
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: dev
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -6,7 +6,7 @@ on:
       - synchronize
       - reopened
     branches:
-      - main
+      - dev
     paths:
       - 'unoplat-code-confluence-commons/**'
       - 'unoplat-code-confluence-ingestion/**'


### PR DESCRIPTION
This commit changes the GitHub Actions workflow to merge pull requests
with the `dev` branch instead of the `main` branch. This allows for
changes to be tested and merged into the development branch before
being promoted to the main branch.