### PR TITLE
fix(discord-notification): Enhance release notification logic

### DIFF
--- a/.github/workflows/discord-release-notification.yaml
+++ b/.github/workflows/discord-release-notification.yaml
@@ -9,12 +9,51 @@ jobs:
     name: Send Discord Notification
     runs-on: ubuntu-latest
     steps:
-      - name: Send Discord Release Notification
+      - name: Determine release target
+        id: release_meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = context.payload.release;
+            if (!release) {
+              throw new Error('Expected release payload but none was found.');
+            }
+
+            const tagName = release.tag_name ?? '';
+            if (!tagName) {
+              throw new Error('Release tag name is missing from the payload.');
+            }
+
+            const component = tagName.split('-v')[0];
+            const isAppRelease = component === 'unoplat-code-confluence';
+
+            core.info(`Parsed component '${component}' from tag '${tagName}'.`);
+            core.setOutput('component', component);
+            core.setOutput('is_app_release', isAppRelease ? 'true' : 'false');
+
+      - name: Send Discord Release Notification for component
+        if: steps.release_meta.outputs.is_app_release != 'true'
         uses: SethCohen/github-releases-to-discord@v1
         with:
           webhook_url: ${{ secrets.DISCORD_UNOPLAT_CODE_CONFLUENCE_WEBHOOK }}
           color: 2105893
-          username: "Unoplat Release Bot"
+          username: "Unoplat Component Release Bot"
+          avatar_url: "https://avatars.githubusercontent.com/${{ github.repository_owner }}"
+          content: "Certified fresh… until the next release"
+          footer_title: "Unoplat Code Confluence Component"
+          footer_icon_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          footer_timestamp: true
+          max_description: 4096
+          remove_github_reference_links: false
+          reduce_headings: false
+      
+      - name: Send Discord Release Notification for App
+        if: steps.release_meta.outputs.is_app_release == 'true'
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.DISCORD_APP_RELEASE_WEBHOOK }}
+          color: 9075499
+          username: "Unoplat App Release Bot"
           avatar_url: "https://avatars.githubusercontent.com/${{ github.repository_owner }}"
           content: "Certified fresh… until the next release"
           footer_title: "Unoplat Code Confluence"
@@ -22,4 +61,4 @@ jobs:
           footer_timestamp: true
           max_description: 4096
           remove_github_reference_links: false
-          reduce_headings: false
+          reduce_headings: false    


### PR DESCRIPTION
### **User description**
Adds logic to determine the release target (component or app) and
send a tailored Discord notification for each case. This ensures
that the notifications are more relevant and informative for the
users.


___

### **PR Type**
Enhancement


___

### **Description**
- Add release target detection logic for components vs apps

- Split Discord notifications into separate component and app workflows

- Configure different webhooks and styling for each release type

- Parse tag names to determine release target automatically


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Triggered"] --> B["Parse Tag Name"]
  B --> C{"Is App Release?"}
  C -->|Yes| D["Send App Notification"]
  C -->|No| E["Send Component Notification"]
  D --> F["Discord App Channel"]
  E --> G["Discord Component Channel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>discord-release-notification.yaml</strong><dd><code>Split Discord notifications by release type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/discord-release-notification.yaml

<ul><li>Add JavaScript logic to parse release tag and determine target type<br> <li> Split single notification step into conditional component/app steps<br> <li> Configure different Discord webhooks and styling for each type<br> <li> Add error handling for missing release payload or tag name</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/847/files#diff-fac81cc3e0d41df40e469cffe7d691e75a744bd52194a1c8c78fceccf536fa47">+42/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

