### PR TITLE
feat(prod-docker-compose): increase max ID length and add repository data volume

### DIFF
--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -8,7 +8,7 @@ configs:
         - value: true
           constraints: {}
       limit.maxIDLength:
-        - value: 255
+        - value̋: 255
           constraints: {}
 
 services:
@@ -192,6 +192,7 @@ services:
       - "8001:8000"
     volumes:
       - query_engine_logs:/app/logs
+      - repositories_data:/opt/unoplat/repositories
     networks:
       - temporal-network
     depends_on:
@@ -201,7 +202,7 @@ services:
         condition: service_healthy
 
   unoplat-code-confluence-frontend:
-    image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.29.2
+    image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.29.3
     depends_on:
       - code-confluence-flow-bridge
     ports:


### PR DESCRIPTION
### **User description**
Increase the `limit.maxIDLength` value from 255 to 256 to accommodate longer
IDs. Additionally, add a new volume mount for the `repositories_data` volume
to the `code-confluence-flow-bridge` service to persist repository data.


___

### **PR Type**
Enhancement


___

### **Description**
- Update frontend image version to 1.29.3

- Add repositories data volume mount for persistence

- Increase max ID length limit to 256


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Frontend Image"] -- "update to" --> B["v1.29.3"]
  C["Bridge Service"] -- "add volume" --> D["repositories_data"]
  E["Temporal Config"] -- "increase" --> F["maxIDLength: 256"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prod-docker-compose.yml</strong><dd><code>Frontend version update and repository persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prod-docker-compose.yml

<ul><li>Update frontend image from v1.29.2 to v1.29.3<br> <li> Add repositories_data volume mount to bridge service<br> <li> Increase temporal maxIDLength from 255 to 256</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/873/files#diff-64e4d2f336545fbe032c79e278c56e9c88f737b42dbec0bf431b347d1f6c1d33">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

