### PR TITLE
fix(ci): Expand release branch condition

### DIFF
--- a/.github/workflows/promote_app_release.yaml
+++ b/.github/workflows/promote_app_release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   app-release:
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev'
+    if: ${{ github.event.pull_request.merged == true && (github.event.pull_request.head.ref == 'dev' || startsWith(github.event.pull_request.head.ref, 'release-please--')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The changes expand the condition for the app-release job to include
release-please-- branches in addition to the 'dev' branch. This allows
the release workflow to be triggered for both development and release
branches.