### PR TITLE
fix(version): update ignore rules for reliable codebase detection across typescript and python

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/detectors/rules.yaml
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/detectors/rules.yaml
@@ -37,6 +37,12 @@ python:
     # Test and coverage
     - htmlcov
     - .coverage
+    # Test directories
+    - test
+    - tests
+    - __tests__
+    - spec
+    - specs
     # IDE and tools
     - .idea
     - .vscode
@@ -95,6 +101,12 @@ typescript:
     - .pnp.loader.mjs
     - .bun
     - .cache
+    # Test directories
+    - test
+    - tests
+    - __tests__
+    - spec
+    - specs
 
   managers:
     # Bun - modern runtime with built-in package manager

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.55.0"
+version = "0.56.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added test directory patterns to ignore rules for Python and TypeScript

- Enhanced codebase detection reliability by excluding common test folders

- Prevents test directories from interfering with package manager detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rules.yaml"] --> B["Python ignore rules"]
  A --> C["TypeScript ignore rules"]
  B --> D["Add test directories"]
  C --> E["Add test directories"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rules.yaml</strong><dd><code>Add test directory ignore patterns for both languages</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/detectors/rules.yaml

<ul><li>Added five test directory patterns (<code>test</code>, <code>tests</code>, <code>__tests__</code>, <code>spec</code>, <br><code>specs</code>) to Python ignore rules<br> <li> Added identical test directory patterns to TypeScript ignore rules<br> <li> Improves codebase detection by excluding common test folder structures</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/903/files#diff-071c2b9a4698d4095fecf2c104665694731931c4bc088766a6470a5da6fbf14e">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

