### PR TITLE
fix(typescript): Improve TypeScript project detection

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "code-confluence-flow-bridge"
-version = "0.56.0"
+version = "0.56.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
### **User description**
Enhance TypeScript project detection by adding more robust
validation checks. Implement methods to detect TypeScript
projects using package.json dependencies and tsconfig files.
Add new utility functions for finding files with specific
content and parsing package.json dependencies.

Includes:
- New detection logic for TypeScript vs JavaScript projects
- Improved logging for project type detection
- Enhanced file search utilities
- Version bump to 0.56.1


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add TypeScript vs JavaScript project validation to prevent false positives

- Implement `find_files_with_content()` for efficient ripgrep-based content search

- Add `parse_package_json_dependencies()` to verify TypeScript in dependency sections

- Enhance detection logic with ordered checks: dependencies first, then tsconfig files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Package Manager Detection"] --> B["TypeScript Validation"]
  B --> C["Check package.json dependencies"]
  C --> D{"typescript found?"}
  D -->|Yes| E["Valid TypeScript Project"]
  D -->|No| F["Check tsconfig files"]
  F --> G{"tsconfig found?"}
  G -->|Yes| E
  G -->|No| H["JavaScript-only Project"]
  H --> I["Skip detection, continue to nested dirs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ripgrep_utils.py</strong><dd><code>Add ripgrep utilities for content search and dependency parsing</code></dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/detectors/ripgrep_utils.py

<ul><li>Add <code>find_files_with_content()</code> function using ripgrep for content-based <br>file search<br> <li> Implement <code>parse_package_json_dependencies()</code> to check TypeScript in <br>dependency sections<br> <li> Import <code>json</code>, <code>Path</code>, <code>Dict</code> types and <code>async_open</code> for async file operations</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/906/files#diff-915c96086d48cbe1253f6f6627056754a82985b37edb0d94ddaef9e26c2b03e2">+138/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>typescript_ripgrep_detector.py</strong><dd><code>Implement TypeScript validation logic in detector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/detectors/typescript_ripgrep_detector.py

<ul><li>Add <code>_is_typescript_project()</code> validation to distinguish TypeScript from <br>JavaScript projects<br> <li> Implement <code>_has_typescript_dependency()</code> to check package.json <br>dependencies<br> <li> Add <code>_has_tsconfig()</code> to detect TypeScript configuration files<br> <li> Update <code>_fast_detect()</code> to skip JavaScript-only directories and allow <br>nested TypeScript detection<br> <li> Enhance <code>_extract_file_patterns()</code> to include <code>tsconfig*.json</code> patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/906/files#diff-4c2f6b827313b06253f36e27ef96a87261181cf29842b9a4e215fdd058c5653c">+150/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

