### PR TITLE
fix(package-manager): common data parsing for typescript across yarn , bun , pnpm and npm and comprehensive package manager tests for TypeScript

### DIFF
--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/package_manager_factory.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/package_manager_factory.py
@@ -31,6 +31,9 @@ class PackageManagerStrategyFactory:
         (ProgrammingLanguage.PYTHON, PackageManagerType.PIP): PipStrategy,
         (ProgrammingLanguage.PYTHON, PackageManagerType.UV): UvStrategy,
         (ProgrammingLanguage.TYPESCRIPT, PackageManagerType.NPM): NodePackageManagerStrategy,
+        (ProgrammingLanguage.TYPESCRIPT, PackageManagerType.YARN): NodePackageManagerStrategy,
+        (ProgrammingLanguage.TYPESCRIPT, PackageManagerType.PNPM): NodePackageManagerStrategy,
+        (ProgrammingLanguage.TYPESCRIPT, PackageManagerType.BUN): NodePackageManagerStrategy,
     }
     
     # Map string names to PackageManagerType enum values
@@ -39,6 +42,9 @@ class PackageManagerStrategyFactory:
         "pip": PackageManagerType.PIP,
         "uv": PackageManagerType.UV,
         "npm": PackageManagerType.NPM,
+        "yarn": PackageManagerType.YARN,
+        "pnpm": PackageManagerType.PNPM,
+        "bun": PackageManagerType.BUN,
     }
 
     @classmethod

--- a/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/package_manager/test_package_manager_factory.py
+++ b/unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/package_manager/test_package_manager_factory.py
@@ -1,0 +1,208 @@
+"""Unit tests for PackageManagerStrategyFactory.
+
+Tests verify that the factory correctly routes programming language and package manager
+combinations to their appropriate strategy implementations.
+"""
+
+import pytest
+from unoplat_code_confluence_commons.programming_language_metadata import (
+    PackageManagerType,
+    ProgrammingLanguage,
+)
+
+from src.code_confluence_flow_bridge.parser.package_manager.node.node_package_manager_strategy import (
+    NodePackageManagerStrategy,
+)
+from src.code_confluence_flow_bridge.parser.package_manager.package_manager_factory import (
+    PackageManagerStrategyFactory,
+    UnsupportedPackageManagerError,
+)
+from src.code_confluence_flow_bridge.parser.package_manager.pip.pip_strategy import (
+    PipStrategy,
+)
+from src.code_confluence_flow_bridge.parser.package_manager.poetry.poetry_strategy import (
+    PythonPoetryStrategy,
+)
+from src.code_confluence_flow_bridge.parser.package_manager.uv.uv_strategy import (
+    UvStrategy,
+)
+
+
+class TestPackageManagerStrategyFactory:
+    """Test suite for PackageManagerStrategyFactory."""
+
+    # TypeScript Package Manager Tests
+
+    def test_get_strategy_typescript_npm(self) -> None:
+        """Verify NPM returns NodePackageManagerStrategy for TypeScript."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.TYPESCRIPT, PackageManagerType.NPM
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_typescript_yarn(self) -> None:
+        """Verify YARN returns NodePackageManagerStrategy for TypeScript."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.TYPESCRIPT, PackageManagerType.YARN
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_typescript_pnpm(self) -> None:
+        """Verify PNPM returns NodePackageManagerStrategy for TypeScript."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.TYPESCRIPT, PackageManagerType.PNPM
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_typescript_bun(self) -> None:
+        """Verify BUN returns NodePackageManagerStrategy for TypeScript."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.TYPESCRIPT, PackageManagerType.BUN
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    # Python Package Manager Tests
+
+    def test_get_strategy_python_poetry(self) -> None:
+        """Verify Poetry returns PythonPoetryStrategy for Python."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.PYTHON, PackageManagerType.POETRY
+        )
+        assert isinstance(strategy, PythonPoetryStrategy)
+
+    def test_get_strategy_python_pip(self) -> None:
+        """Verify Pip returns PipStrategy for Python."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.PYTHON, PackageManagerType.PIP
+        )
+        assert isinstance(strategy, PipStrategy)
+
+    def test_get_strategy_python_uv(self) -> None:
+        """Verify UV returns UvStrategy for Python."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.PYTHON, PackageManagerType.UV
+        )
+        assert isinstance(strategy, UvStrategy)
+
+    # Name-based Strategy Resolution Tests
+
+    def test_get_strategy_from_name_npm(self) -> None:
+        """Verify name-based lookup works for npm."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.TYPESCRIPT, "npm"
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_from_name_yarn(self) -> None:
+        """Verify name-based lookup works for yarn."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.TYPESCRIPT, "yarn"
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_from_name_pnpm(self) -> None:
+        """Verify name-based lookup works for pnpm."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.TYPESCRIPT, "pnpm"
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_from_name_bun(self) -> None:
+        """Verify name-based lookup works for bun."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.TYPESCRIPT, "bun"
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    def test_get_strategy_from_name_poetry(self) -> None:
+        """Verify name-based lookup works for poetry."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.PYTHON, "poetry"
+        )
+        assert isinstance(strategy, PythonPoetryStrategy)
+
+    def test_get_strategy_from_name_pip(self) -> None:
+        """Verify name-based lookup works for pip."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.PYTHON, "pip"
+        )
+        assert isinstance(strategy, PipStrategy)
+
+    def test_get_strategy_from_name_uv(self) -> None:
+        """Verify name-based lookup works for uv."""
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            ProgrammingLanguage.PYTHON, "uv"
+        )
+        assert isinstance(strategy, UvStrategy)
+
+    # Error Case Tests
+
+    def test_get_strategy_unsupported_combination(self) -> None:
+        """Verify UnsupportedPackageManagerError for invalid language/manager combination."""
+        # Python with TypeScript package manager should fail
+        with pytest.raises(UnsupportedPackageManagerError) as exc_info:
+            PackageManagerStrategyFactory.get_strategy(
+                ProgrammingLanguage.PYTHON, PackageManagerType.NPM
+            )
+
+        assert "Unsupported combination" in str(exc_info.value)
+        assert "python" in str(exc_info.value).lower()
+        assert "npm" in str(exc_info.value).lower()
+
+    def test_get_strategy_from_name_unknown_manager(self) -> None:
+        """Verify UnsupportedPackageManagerError for unknown package manager name."""
+        with pytest.raises(UnsupportedPackageManagerError) as exc_info:
+            PackageManagerStrategyFactory.get_strategy_from_name(
+                ProgrammingLanguage.TYPESCRIPT, "unknown-manager"
+            )
+
+        assert "Unsupported package manager name" in str(exc_info.value)
+        assert "unknown-manager" in str(exc_info.value)
+
+    # Parametrized Tests for All TypeScript Package Managers
+
+    @pytest.mark.parametrize(
+        "package_manager_type",
+        [
+            PackageManagerType.NPM,
+            PackageManagerType.YARN,
+            PackageManagerType.PNPM,
+            PackageManagerType.BUN,
+        ],
+    )
+    def test_all_typescript_managers_return_node_strategy(
+        self, package_manager_type: PackageManagerType
+    ) -> None:
+        """Verify all TypeScript package managers return NodePackageManagerStrategy."""
+        strategy = PackageManagerStrategyFactory.get_strategy(
+            ProgrammingLanguage.TYPESCRIPT, package_manager_type
+        )
+        assert isinstance(strategy, NodePackageManagerStrategy)
+
+    @pytest.mark.parametrize(
+        "manager_name,expected_strategy_type",
+        [
+            ("npm", NodePackageManagerStrategy),
+            ("yarn", NodePackageManagerStrategy),
+            ("pnpm", NodePackageManagerStrategy),
+            ("bun", NodePackageManagerStrategy),
+            ("poetry", PythonPoetryStrategy),
+            ("pip", PipStrategy),
+            ("uv", UvStrategy),
+        ],
+    )
+    def test_name_to_strategy_mapping(
+        self, manager_name: str, expected_strategy_type: type
+    ) -> None:
+        """Verify name-based lookup returns correct strategy type."""
+        # Determine language based on manager name
+        language = (
+            ProgrammingLanguage.TYPESCRIPT
+            if manager_name in {"npm", "yarn", "pnpm", "bun"}
+            else ProgrammingLanguage.PYTHON
+        )
+
+        strategy = PackageManagerStrategyFactory.get_strategy_from_name(
+            language, manager_name
+        )
+        assert isinstance(strategy, expected_strategy_type)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add support for YARN, PNPM, and BUN package managers for TypeScript

- Map all TypeScript package managers to unified NodePackageManagerStrategy

- Add comprehensive factory tests for all package manager combinations

- Add parametrized tests for cross-package-manager compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Factory["PackageManagerStrategyFactory"]
  NPM["NPM"]
  YARN["YARN"]
  PNPM["PNPM"]
  BUN["BUN"]
  NodeStrategy["NodePackageManagerStrategy"]
  
  Factory -- "TypeScript + NPM" --> NPM
  Factory -- "TypeScript + YARN" --> YARN
  Factory -- "TypeScript + PNPM" --> PNPM
  Factory -- "TypeScript + BUN" --> BUN
  
  NPM --> NodeStrategy
  YARN --> NodeStrategy
  PNPM --> NodeStrategy
  BUN --> NodeStrategy
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package_manager_factory.py</strong><dd><code>Register YARN, PNPM, BUN with factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/src/code_confluence_flow_bridge/parser/package_manager/package_manager_factory.py

<ul><li>Added YARN, PNPM, and BUN to TypeScript strategy mappings<br> <li> All three new package managers map to NodePackageManagerStrategy<br> <li> Updated manager name-to-type mapping dictionary with new package <br>managers<br> <li> Enables unified handling of all Node.js-based package managers</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/908/files#diff-6b0a4b4259dac9da3ea0c2094a0559f317e529445303ff3b03672c8932bb7f74">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_node_package_manager_strategy.py</strong><dd><code>Add parametrized tests for all package managers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/package_manager/node/test_node_package_manager_strategy.py

<ul><li>Added parametrized fixture <code>node_metadata_all_managers</code> for testing all <br>TypeScript package managers<br> <li> Fixture tests NPM, YARN, PNPM, and BUN combinations<br> <li> Added <code>test_all_typescript_package_managers</code> test to verify strategy <br>works across all managers<br> <li> Test validates metadata processing, package manager preservation, and <br>dependency parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/908/files#diff-00d8d624a14eacccbf6334e0e8b8dd46e7a76facbee581909d33e157d739ca0b">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_package_manager_factory.py</strong><dd><code>Create comprehensive factory test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-ingestion/code-confluence-flow-bridge/tests/parser/package_manager/test_package_manager_factory.py

<ul><li>Created comprehensive test suite for PackageManagerStrategyFactory<br> <li> Added individual tests for each TypeScript package manager (NPM, YARN, <br>PNPM, BUN)<br> <li> Added individual tests for each Python package manager (Poetry, Pip, <br>UV)<br> <li> Added name-based strategy resolution tests for all managers<br> <li> Added error case tests for unsupported combinations and unknown <br>managers<br> <li> Added parametrized tests for all TypeScript managers and <br>name-to-strategy mappings</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/908/files#diff-202cc1deb5b5ff695a773dbb7f8b8cf9539b465cc83e4b078ff75eda84cb8dc9">+208/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

