### PR TITLE
feat(repo_models): Add statistics column for agent workflow metrics

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py
@@ -286,6 +286,12 @@ class RepositoryAgentMdSnapshot(SQLBase):
         nullable=False,
         comment="Complete final payload from agent execution containing per-codebase agent data",
     )
+    statistics: Mapped[Optional[Dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=True,
+        default=None,
+        comment="Aggregated usage and pricing statistics for the latest agent workflow",
+    )
     status: Mapped[RepoAgentSnapshotStatus] = mapped_column(
         SQLEnum(
             RepoAgentSnapshotStatus,


### PR DESCRIPTION
### **User description**
Extend RepoAgentSnapshot model with a new optional JSONB column
to store aggregated usage and pricing statistics for the latest
agent workflow execution. This enables tracking and analyzing
performance metrics for each repository agent snapshot.


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional `statistics` JSONB column to `RepositoryAgentMdSnapshot` model

- Store aggregated usage and pricing metrics for agent workflows

- Enable performance tracking and analysis per repository agent snapshot


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RepositoryAgentMdSnapshot Model"] -- "adds statistics column" --> B["JSONB Optional Field"]
  B -- "stores" --> C["Usage and Pricing Statistics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repo_models.py</strong><dd><code>Add statistics JSONB column to agent snapshot model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py

<ul><li>Added new optional <code>statistics</code> field to <code>RepositoryAgentMdSnapshot</code> class<br> <li> Field type is <code>Mapped[Optional[Dict[str, Any]]]</code> with JSONB storage<br> <li> Default value set to <code>None</code> with nullable constraint<br> <li> Includes descriptive comment for aggregated workflow metrics</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/930/files#diff-f2e444caa052dd965111a885baa0a293e85e3ae046e18f4410fe49f4485ce53d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

