### PR TITLE
chore(docker-compose): Update service images to latest versions

### DIFF
--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -53,7 +53,6 @@ services:
       timeout: 5s
       retries: 5
 
-
   electric:
     image: docker.io/electricsql/electric:latest
     environment:
@@ -68,7 +67,6 @@ services:
     depends_on:
       postgresql:
         condition: service_healthy
-
 
   temporal:
     depends_on:
@@ -149,7 +147,7 @@ services:
       timeout: 5s
       retries: 5
   code-confluence-flow-bridge:
-    image: ghcr.io/unoplat/code-confluence-flow-bridge:0.53.1
+    image: ghcr.io/unoplat/code-confluence-flow-bridge:0.59.0
     environment:
       - NEO4J_HOST=neo4j
       - NEO4J_PORT=7687
@@ -176,7 +174,7 @@ services:
     stdin_open: true
     tty: true
   unoplat-code-confluence-query-engine:
-    image: ghcr.io/unoplat/unoplat-code-confluence-query-engine:0.15.2
+    image: ghcr.io/unoplat/unoplat-code-confluence-query-engine:0.20.0
     environment:
       - NEO4J_HOST=neo4j
       - NEO4J_PORT=7687
@@ -202,7 +200,7 @@ services:
         condition: service_healthy
 
   unoplat-code-confluence-frontend:
-    image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.29.3
+    image: ghcr.io/unoplat/unoplat-code-confluence-frontend:1.31.0
     depends_on:
       - code-confluence-flow-bridge
     ports:


### PR DESCRIPTION
### **User description**
Update multiple service images to their latest versions:
- code-confluence-flow-bridge: 0.53.1 -> 0.59.0
- unoplat-code-confluence-query-engine: 0.15.2 -> 0.20.0
- unoplat-code-confluence-frontend: 1.29.3 -> 1.31.0

Remove unnecessary blank lines in docker-compose configuration


___

### **PR Type**
Enhancement


___

### **Description**
- Update code-confluence-flow-bridge from 0.53.1 to 0.59.0

- Update unoplat-code-confluence-query-engine from 0.15.2 to 0.20.0

- Update unoplat-code-confluence-frontend from 1.29.3 to 1.31.0

- Remove unnecessary blank lines in docker-compose configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["prod-docker-compose.yml"] -->|"Update flow-bridge 0.53.1→0.59.0"| B["Service Images"]
  A -->|"Update query-engine 0.15.2→0.20.0"| B
  A -->|"Update frontend 1.29.3→1.31.0"| B
  A -->|"Remove blank lines"| C["Configuration Cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prod-docker-compose.yml</strong><dd><code>Update service images and remove blank lines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prod-docker-compose.yml

<ul><li>Updated <code>code-confluence-flow-bridge</code> image tag from 0.53.1 to 0.59.0<br> <li> Updated <code>unoplat-code-confluence-query-engine</code> image tag from 0.15.2 to <br>0.20.0<br> <li> Updated <code>unoplat-code-confluence-frontend</code> image tag from 1.29.3 to <br>1.31.0<br> <li> Removed unnecessary blank lines between service definitions for <br>cleaner formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/939/files#diff-64e4d2f336545fbe032c79e278c56e9c88f737b42dbec0bf431b347d1f6c1d33">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

