### PR TITLE
feat(credentials): Refactor authentication/authorisation schema to support pat based login across repository providers, support for oauth and webhook based integrations

### DIFF
--- a/unoplat-code-confluence-commons/Taskfile.yml
+++ b/unoplat-code-confluence-commons/Taskfile.yml
@@ -17,7 +17,7 @@ tasks:
     deps: [install]
     cmds:
       - uv run pytest -v -f tests/
-
+  
   all:
     desc: Run all checks (install, test)
     cmds:

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
@@ -57,6 +57,11 @@ from unoplat_code_confluence_commons.base_models import (
     deserialize_structural_signature,
     get_signature_type_for_language,
 )
+from unoplat_code_confluence_commons.credential_enums import (
+    CredentialNamespace,
+    ProviderKey,
+    SecretKind,
+)
 from unoplat_code_confluence_commons.graph_models import (
     BaseNode,
     CodeConfluenceCodebase,
@@ -138,8 +143,11 @@ __all__ = [
     'PackageManagerType',
     'RepositoryAgentMdSnapshot',
     'RepoAgentSnapshotStatus',
-    # Credentials model
+    # Credentials and related enums
     'Credentials',
+    'CredentialNamespace',
+    'ProviderKey',
+    'SecretKind',
     # Flags model
     'Flag',
     # Security utilities

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/sql_base.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/sql_base.py
@@ -12,10 +12,12 @@ class SQLBase(DeclarativeBase):
     
     This base class provides the foundation for all SQL table models
     in the unoplat-code-confluence project, enabling proper typing
-    and modern SQLAlchemy 2.0 patterns with Mapped[T] and mapped_column.
+    and modern SQLAlchemy 2.0 patterns with Mapped[T] and mapped_column. The reason we use native_enum=False is to ensure that the enum values are stored as strings in the database, rather than as integers. This is important for consistency and compatibility with other systems that may not support integer-based enums. So it helps with migrations and portability. 
     """
     
     type_annotation_map = {
         # Global enum configuration - automatically maps Python enums to SQLAlchemy Enum
-        enum.Enum: sqlalchemy.Enum(enum.Enum),
+        enum.Enum: sqlalchemy.Enum(enum.Enum,native_enum=False),
     }
+    
+    

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credential_enums.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credential_enums.py
@@ -1,0 +1,36 @@
+from enum import Enum
+
+
+class CredentialNamespace(str, Enum):
+    REPOSITORY = "repository"
+    MODEL = "MODEL"
+    WEBHOOK = "WEBHOOK"
+    IDENTITY = "IDENTITY"
+
+
+class ProviderKey(str, Enum):
+    GITHUB_OPEN = "github_open"
+    GITHUB_ENTERPRISE = "github_enterprise"
+    GITLAB_CE = "gitlab_ce"
+    GITLAB_ENTERPRISE = "gitlab_enterprise"
+    GOOGLE_AUTH = "google_oauth"
+    GITHUB_AUTH = "github_oauth"
+    MODEL_PROVIDER_AUTH = "model_provider_auth"
+
+
+class SecretKind(str, Enum):
+    PAT = "pat"
+
+    MODEL_API_KEY = "model_api_key"
+
+    APP_PRIVATE_KEY = "app_private_key"
+    APP_WEBHOOK_SECRET = "app_webhook_secret"
+    APP_CLIENT_SECRET = "app_client_secret"
+    APP_CLIENT_ID = "app_client_id"
+    APP_INSTALLATION_TOKEN = "app_installation_token"
+
+    OAUTH_ACCESS_TOKEN = "oauth_access_token"
+    OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
+    OAUTH_ID_TOKEN = "oauth_id_token"
+
+    JWT_SECRET = "jwt_secret"

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credentials.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credentials.py
@@ -1,31 +1,48 @@
 """Credentials SQLModel for storing encrypted credentials with support for multiple credential types."""
 
 from unoplat_code_confluence_commons.base_models.sql_base import SQLBase
+from unoplat_code_confluence_commons.credential_enums import (
+    CredentialNamespace,
+    ProviderKey,
+    SecretKind,
+)
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
+import uuid
 
 from sqlalchemy import Index
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql.sqltypes import DateTime
 
 
 class Credentials(SQLBase):
     """Model for storing encrypted credentials with support for multiple credential types."""
-    
+
     __tablename__ = "credentials"
     __table_args__ = (
         # Add unique constraint on credential_key for multi-key credential support
-        Index('ix_credentials_credential_key', 'credential_key', unique=True),
+        Index(
+            "uq_credentials_namespace_provider_secret",
+            "namespace",
+            "provider_key",
+            "secret_kind",
+            unique=True,
+        ),
         # Keep existing unique constraint on token_hash for backward compatibility
     )
-    
-    credential_key: Mapped[str] = mapped_column(
-        primary_key=True,
-        comment="Stable identifier for this credential (e.g., 'github_pat', 'model_api_key')"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    namespace: Mapped[CredentialNamespace] = mapped_column(nullable=False)
+    provider_key: Mapped[ProviderKey] = mapped_column(nullable=False)
+    secret_kind: Mapped[SecretKind] = mapped_column(nullable=False)
+    token_hash: Mapped[str] = mapped_column(comment="Encrypted credential value")
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, default=None, comment="Provider specific metadata"
     )
-    token_hash: Mapped[str] = mapped_column(
-        comment="Encrypted credential value"
+    created_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), default=None
     )
-    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)
-    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), default=None
+    )

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py
@@ -1,4 +1,5 @@
 from unoplat_code_confluence_commons.base_models.sql_base import SQLBase
+from unoplat_code_confluence_commons.credential_enums import ProviderKey
 
 from datetime import datetime
 from enum import Enum
@@ -45,11 +46,11 @@ class Repository(SQLBase):
     repository_owner_name: Mapped[str] = mapped_column(
         primary_key=True, comment="The name of the repository owner"
     )
-    repository_provider: Mapped[RepositoryProvider] = mapped_column(
-        SQLEnum(RepositoryProvider, name="repository_provider_type", native_enum=False),
-        default=RepositoryProvider.GITHUB_OPEN,
+    repository_provider: Mapped[ProviderKey] = mapped_column(
+        SQLEnum(ProviderKey, name="repository_provider_type", native_enum=False),
+        default=ProviderKey.GITHUB_OPEN,
         nullable=False,
-        comment="Git provider type for this repository (e.g., GitHub, GitLab, Bitbucket)",
+        comment="Provider key for this repository (e.g., GITHUB_OPEN, GITHUB_ENTERPRISE, GITLAB_CE, GITLAB_ENTERPRISE)",
     )
 
     # Relationships - will be populated after class definitions

--- a/unoplat-code-confluence-commons/uv.lock
+++ b/unoplat-code-confluence-commons/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.32.2"
+version = "0.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
### **User description**
Introduce comprehensive credential management with new enums and
improved Credentials model. Changes include:

- Add CredentialNamespace, ProviderKey, and SecretKind enums
- Modify Credentials model with more granular identification
- Replace credential_key with namespace, provider_key, and secret_kind
- Add metadata_json field for provider-specific information
- Update SQLBase to use native_enum=False for better compatibility
- Expose new enums in package exports


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce comprehensive credential management system with three new enums
  - `CredentialNamespace`: Repository, Model, Webhook, Identity
  - `ProviderKey`: GitHub, GitLab, Google, Model providers
  - `SecretKind`: PAT, API keys, OAuth tokens, JWT secrets

- Refactor `Credentials` model with granular identification fields
  - Replace single `credential_key` with `namespace`, `provider_key`, `secret_kind`
  - Add UUID primary key and `metadata_json` for provider-specific data
  - Update unique constraint to composite key across three fields

- Update `Repository` model to use new `ProviderKey` enum

- Configure SQLAlchemy enums to store as strings for portability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New Credential Enums<br/>CredentialNamespace<br/>ProviderKey<br/>SecretKind"] -->|"replaces single key"| B["Credentials Model<br/>namespace + provider_key<br/>+ secret_kind"]
  B -->|"adds metadata support"| C["metadata_json Field<br/>Provider-specific data"]
  A -->|"used by"| D["Repository Model<br/>repository_provider"]
  E["SQLBase Config<br/>native_enum=False"] -->|"ensures"| F["String-based Enum Storage<br/>Database portability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>credential_enums.py</strong><dd><code>New credential enums for multi-provider support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credential_enums.py

<ul><li>New file introducing three credential-related enums<br> <li> <code>CredentialNamespace</code>: Defines credential scopes (repository, model, <br>webhook, identity)<br> <li> <code>ProviderKey</code>: Enumerates supported providers (GitHub, GitLab, Google, <br>model providers)<br> <li> <code>SecretKind</code>: Categorizes secret types (PAT, API keys, OAuth tokens, JWT <br>secrets)</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/947/files#diff-1272b6117c0501e4f998bf7fc098e10fa17cb1fb2a470da509f609679b98d415">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>credentials.py</strong><dd><code>Refactor Credentials model with granular identification</code>&nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credentials.py

<ul><li>Replace <code>credential_key</code> primary key with UUID <code>id</code> field<br> <li> Add three new fields: <code>namespace</code>, <code>provider_key</code>, <code>secret_kind</code> using new <br>enums<br> <li> Add <code>metadata_json</code> JSONB field for provider-specific metadata<br> <li> Update unique constraint to composite key on namespace, provider_key, <br>secret_kind<br> <li> Add <code>created_at</code> and <code>updated_at</code> timestamp fields with timezone support</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/947/files#diff-a0493d198d2cb1661bd23e5511a3e9ab5ae7ed1ce490eea2a315b98501fb3a37">+28/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repo_models.py</strong><dd><code>Migrate Repository to use ProviderKey enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/repo_models.py

<ul><li>Update <code>Repository.repository_provider</code> field type from <br><code>RepositoryProvider</code> to <code>ProviderKey</code><br> <li> Change default value from <code>RepositoryProvider.GITHUB_OPEN</code> to <br><code>ProviderKey.GITHUB_OPEN</code><br> <li> Update field comment to reference new provider key values</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/947/files#diff-f2e444caa052dd965111a885baa0a293e85e3ae046e18f4410fe49f4485ce53d">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export new credential enums in package API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py

<ul><li>Import new credential enums from <code>credential_enums</code> module<br> <li> Export <code>CredentialNamespace</code>, <code>ProviderKey</code>, <code>SecretKind</code> in public API<br> <li> Update <code>__all__</code> list with new enum exports and clarified credentials <br>section</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/947/files#diff-2d6c5fd2e21027f0dc107ed1c4f30ee737aabbf48d7d0d9f461fb52d5c82eb15">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_base.py</strong><dd><code>Configure SQLAlchemy enums for string storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/sql_base.py

<ul><li>Configure SQLAlchemy enum mapping with <code>native_enum=False</code><br> <li> Add detailed documentation explaining string-based enum storage for <br>portability<br> <li> Ensures consistency across database systems and migration <br>compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/947/files#diff-9254b362451098c95abfa38712b627dd97a916bf442f931b45a79b2e10b88bb0">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Taskfile.yml</strong><dd><code>Whitespace formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

unoplat-code-confluence-commons/Taskfile.yml

- Minor whitespace formatting adjustment in test:watch task


</details>


  </td>
  <td><a href="https://github.com/unoplat/unoplat-code-confluence/pull/947/files#diff-e8c897085842581bbb910b4acb74adcc34e743547f088978d42a8b11533d9881">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

