### PR TITLE
fix(credentials): Update metadata_json column to be nullable

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credentials.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/credentials.py
@@ -14,6 +14,7 @@ import uuid
 from sqlalchemy import Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql.expression import null
 from sqlalchemy.sql.sqltypes import DateTime
 
 
@@ -37,8 +38,8 @@ class Credentials(SQLBase):
     provider_key: Mapped[ProviderKey] = mapped_column(nullable=False)
     secret_kind: Mapped[SecretKind] = mapped_column(nullable=False)
     token_hash: Mapped[str] = mapped_column(comment="Encrypted credential value")
-    metadata_json: Mapped[dict[str, Any]] = mapped_column(
-        JSONB, default=None, comment="Provider specific metadata"
+    metadata_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSONB, default=None, comment="Provider specific metadata", nullable=True
     )
     created_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), default=None

--- a/unoplat-code-confluence-commons/uv.lock
+++ b/unoplat-code-confluence-commons/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "unoplat-code-confluence-commons"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Modify the metadata_json column in the credentials model to explicitly
support nullable values and improve type hinting. Import null from
sqlalchemy.sql.expression to support the change. Bump package version
to 0.34.0 to reflect the model modification.