### PR TITLE
fix(ci): Enable docs deployment for dev branch

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./code-confluence/build


### PR DESCRIPTION
Modify GitHub Actions workflow to deploy documentation
from both main and dev branches, expanding deployment
flexibility and improving documentation accessibility
for development versions.