### PR TITLE
feat(agent-events): virtualize agent group events with sticky auto-scroll

- Replace flat event list with VirtualizedAgentGroupEvents using @tanstack/react-virtual
- Add isNearBottomRef guard so auto-scroll only fires when user is near bottom
- Extend ScrollArea with viewportClassName prop to support overflow-anchor:none

### DIFF
--- a/unoplat-code-confluence-frontend/src/components/custom/agent-events/AgentEventsAccordion.tsx
+++ b/unoplat-code-confluence-frontend/src/components/custom/agent-events/AgentEventsAccordion.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { AgentEventItem } from "@/components/custom/agent-events/AgentEventItem";
 import { AgentGroupHeader } from "@/components/custom/agent-events/AgentGroupHeader";
@@ -9,8 +10,146 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildEventDisplayItems, groupEventsByAgent } from "@/lib/agent-events-utils";
+import type { RepositoryAgentEvent } from "@/features/repository-agent-snapshots/schema";
 import type { AgentEventsAccordionProps, ToolDetailItem } from "@/types/agent-events";
+
+const ROW_ESTIMATE_PX = 96;
+const ROW_OVERSCAN = 5;
+const NEAR_BOTTOM_ROW_TOLERANCE = 2;
+
+interface VirtualizedAgentGroupEventsProps {
+  events: RepositoryAgentEvent[];
+  onViewDetails: (item: ToolDetailItem) => void;
+}
+
+function VirtualizedAgentGroupEvents({
+  events,
+  onViewDetails,
+}: VirtualizedAgentGroupEventsProps): React.ReactElement {
+  const items = React.useMemo(() => buildEventDisplayItems(events), [events]);
+  const viewportRef = React.useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => viewportRef.current,
+    estimateSize: () => ROW_ESTIMATE_PX,
+    overscan: ROW_OVERSCAN,
+    getItemKey: (index) => items[index]?.key ?? index,
+    useFlushSync: false,
+  });
+
+  const previousItemsCountRef = React.useRef<number>(0);
+  const isNearBottomRef = React.useRef<boolean>(true);
+  const itemsCountRef = React.useRef<number>(items.length);
+
+  React.useLayoutEffect(() => {
+    itemsCountRef.current = items.length;
+  }, [items.length]);
+
+  React.useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return undefined;
+    }
+
+    function handleScroll(): void {
+      const virtualItems = rowVirtualizer.getVirtualItems();
+      const lastVisible = virtualItems[virtualItems.length - 1];
+      const totalCount = itemsCountRef.current;
+
+      if (totalCount === 0 || !lastVisible) {
+        isNearBottomRef.current = true;
+        return;
+      }
+
+      isNearBottomRef.current =
+        lastVisible.index >= totalCount - 1 - NEAR_BOTTOM_ROW_TOLERANCE;
+    }
+
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      viewport.removeEventListener("scroll", handleScroll);
+    };
+  }, [rowVirtualizer]);
+
+  React.useEffect(() => {
+    const previousCount = previousItemsCountRef.current;
+    previousItemsCountRef.current = items.length;
+
+    if (items.length === 0) {
+      return undefined;
+    }
+
+    const isInitialMount = previousCount === 0;
+    const grew = items.length > previousCount;
+    const shouldFollow = isInitialMount || (grew && isNearBottomRef.current);
+
+    if (!shouldFollow) {
+      return undefined;
+    }
+
+    const targetIndex = items.length - 1;
+    const frameId = requestAnimationFrame(() => {
+      rowVirtualizer.scrollToIndex(targetIndex, { align: "end" });
+      isNearBottomRef.current = true;
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [items.length, rowVirtualizer]);
+
+  if (items.length === 0) {
+    return (
+      <p className="text-muted-foreground text-xs">No events recorded yet.</p>
+    );
+  }
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+
+  return (
+    <ScrollArea
+      className="h-72 w-full"
+      viewportRef={viewportRef}
+      viewportClassName="[overflow-anchor:none]"
+    >
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: `${rowVirtualizer.getTotalSize()}px`,
+        }}
+      >
+        {virtualRows.map((virtualRow) => {
+          const item = items[virtualRow.index];
+          if (!item) {
+            return null;
+          }
+
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${virtualRow.start}px)`,
+                paddingBottom: "8px",
+              }}
+            >
+              <AgentEventItem item={item} onViewDetails={onViewDetails} />
+            </div>
+          );
+        })}
+      </div>
+    </ScrollArea>
+  );
+}
 
 export function AgentEventsAccordion({
   events,
@@ -52,8 +191,6 @@ export function AgentEventsAccordion({
             return null;
           }
 
-          const items = buildEventDisplayItems(group.events);
-
           return (
             <AccordionItem
               key={group.agentId}
@@ -64,15 +201,10 @@ export function AgentEventsAccordion({
                 <AgentGroupHeader group={group} />
               </AccordionTrigger>
               <AccordionContent className="px-4 pb-3 pt-1">
-                <section className="space-y-2">
-                  {items.map((item) => (
-                    <AgentEventItem
-                      key={item.key}
-                      item={item}
-                      onViewDetails={setDetailItem}
-                    />
-                  ))}
-                </section>
+                <VirtualizedAgentGroupEvents
+                  events={group.events}
+                  onViewDetails={setDetailItem}
+                />
               </AccordionContent>
             </AccordionItem>
           );

--- a/unoplat-code-confluence-frontend/src/components/ui/scroll-area.tsx
+++ b/unoplat-code-confluence-frontend/src/components/ui/scroll-area.tsx
@@ -8,10 +8,11 @@ import { cn } from "@/lib/utils";
 interface ScrollAreaProps
   extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
   viewportRef?: React.RefObject<HTMLDivElement | null>;
+  viewportClassName?: string;
 }
 
 const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
-  ({ className, children, viewportRef, ...props }, ref) => (
+  ({ className, children, viewportRef, viewportClassName, ...props }, ref) => (
     <ScrollAreaPrimitive.Root
       ref={ref}
       className={cn("relative overflow-hidden", className)}
@@ -19,7 +20,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
     >
       <ScrollAreaPrimitive.Viewport
         ref={viewportRef}
-        className="h-full w-full rounded-[inherit]"
+        className={cn("h-full w-full rounded-[inherit]", viewportClassName)}
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized agent events list rendering for improved performance
  * Added automatic scroll-to-bottom when new events are appended
  * Improved empty state messaging for event lists with no recorded events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->