### PR TITLE
feat(add-setup-commands): add setup commands

### DIFF
--- a/unoplat-code-confluence-cli/README.md
+++ b/unoplat-code-confluence-cli/README.md
@@ -1,0 +1,37 @@
+# Unoplat Code Confluence CLI
+
+The `unoplat` CLI starts the local Unoplat Code Confluence app and opens setup pages in your browser.
+
+## Setup commands
+
+```bash
+unoplat setup token-repo-provider
+```
+
+Ensures the local app is running, then opens the repository token/provider setup page:
+
+```text
+http://localhost:3000/onboarding/github
+```
+
+```bash
+unoplat setup model-provider
+```
+
+Ensures the local app is running, then opens the model-provider setup page:
+
+```text
+http://localhost:3000/settings/model-providers
+```
+
+Both commands emit JSON containing the setup target, opened URL, and whether Python's standard browser opener reported success. They do not persist provider identifiers, selected model-provider identifiers, or setup completion state.
+
+## Frontend URL override
+
+The frontend base URL defaults to `http://localhost:3000`. Override it with:
+
+```bash
+export UNOPLAT_CODE_CONFLUENCE_FRONTEND_URL="http://localhost:5173"
+```
+
+The setup commands append their route paths to this base URL.

--- a/unoplat-code-confluence-cli/src/unoplat_code_confluence_cli/cli.py
+++ b/unoplat-code-confluence-cli/src/unoplat_code_confluence_cli/cli.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import click
 
-from unoplat_code_confluence_cli.app_runtime import AppRuntimeError, run_app, update_app
+from unoplat_code_confluence_cli.app_runtime import (
+    AppRuntimeError,
+    ensure_app_running,
+    run_app,
+    update_app,
+)
 from unoplat_code_confluence_cli.config import CliSettings
+from unoplat_code_confluence_cli.setup_runtime import open_setup_url
 
 
 def progress(message: str) -> None:
@@ -32,6 +38,43 @@ def update() -> None:
     settings = CliSettings()
     try:
         result = update_app(settings, progress=progress)
+    except AppRuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(result.model_dump_json(indent=2))
+
+
+@main.group(name="setup")
+def setup() -> None:
+    """Open setup pages in the Unoplat Code Confluence app."""
+
+
+@setup.command(name="token-repo-provider")
+def setup_token_repo_provider() -> None:
+    """Open the GitHub repository-provider setup page."""
+    settings = CliSettings()
+    try:
+        ensure_app_running(settings)
+        result = open_setup_url(
+            settings,
+            setup_target="token-repo-provider",
+            path="/onboarding/github",
+        )
+    except AppRuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(result.model_dump_json(indent=2))
+
+
+@setup.command(name="model-provider")
+def setup_model_provider() -> None:
+    """Open the model-provider setup page."""
+    settings = CliSettings()
+    try:
+        ensure_app_running(settings)
+        result = open_setup_url(
+            settings,
+            setup_target="model-provider",
+            path="/settings/model-providers",
+        )
     except AppRuntimeError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(result.model_dump_json(indent=2))

--- a/unoplat-code-confluence-cli/src/unoplat_code_confluence_cli/config.py
+++ b/unoplat-code-confluence-cli/src/unoplat_code_confluence_cli/config.py
@@ -57,6 +57,11 @@ class CliSettings(BaseSettings):
     def release_state_path(self) -> Path:
         return self.resolved_data_dir / "release-state.json"
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def setup_metadata_path(self) -> Path:
+        return self.resolved_data_dir / "setup-metadata.json"
+
     @property
     def github_api_base(self) -> str:
         return str(self.github_api_base_url).rstrip("/")

--- a/unoplat-code-confluence-cli/src/unoplat_code_confluence_cli/setup_runtime.py
+++ b/unoplat-code-confluence-cli/src/unoplat_code_confluence_cli/setup_runtime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import webbrowser
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, AnyUrl
+
+from unoplat_code_confluence_cli.config import CliSettings
+
+
+class SetupOpenResult(BaseModel):
+    """Result emitted by setup commands after opening a frontend setup URL."""
+
+    model_config = ConfigDict(frozen=True)
+
+    setup_target: Literal["token-repo-provider", "model-provider"]
+    url: AnyUrl
+    opened: bool
+
+
+def setup_url(settings: CliSettings, path: str) -> str:
+    """Build a setup URL from the configured frontend base URL and route path."""
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    return f"{settings.frontend_base_url}{normalized_path}"
+
+
+def open_setup_url(
+    settings: CliSettings,
+    *,
+    setup_target: Literal["token-repo-provider", "model-provider"],
+    path: str,
+) -> SetupOpenResult:
+    """Open a setup route in the user's default browser."""
+    url = setup_url(settings, path)
+    opened = webbrowser.open(url)
+    return SetupOpenResult(setup_target=setup_target, url=AnyUrl(url), opened=opened)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced CLI setup commands: `setup token-repo-provider` and `setup model-provider`
  * Setup commands automatically launch browser-based onboarding flows and output JSON results
  * Support customization of frontend base URL via environment variable

* **Documentation**
  * Added comprehensive setup command documentation with usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->