### PR TITLE
chore(skills): untrack skills/ symlink mirror and dedupe .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,11 +373,7 @@ node_modules/
 unoplat-code-confluence-ingestion/code-confluence-flow-bridge/experiments
 experiments/
 
-# Local agent/tooling directories (keep out of git)
-skills/
-skills-lock.json
-.agents/skills/
-.agent/skills/
+# Per-agent skills directories (skills/, .agents/, .agent/ already ignored above)
 .claude/skills/
 .codex/skills/
 .gemini/skills/

--- a/skills/adapt
+++ b/skills/adapt
@@ -1,1 +1,0 @@
-../.agents/skills/adapt

--- a/skills/animate
+++ b/skills/animate
@@ -1,1 +1,0 @@
-../.agents/skills/animate

--- a/skills/audit
+++ b/skills/audit
@@ -1,1 +1,0 @@
-../.agents/skills/audit

--- a/skills/bolder
+++ b/skills/bolder
@@ -1,1 +1,0 @@
-../.agents/skills/bolder

--- a/skills/clarify
+++ b/skills/clarify
@@ -1,1 +1,0 @@
-../.agents/skills/clarify

--- a/skills/colorize
+++ b/skills/colorize
@@ -1,1 +1,0 @@
-../.agents/skills/colorize

--- a/skills/critique
+++ b/skills/critique
@@ -1,1 +1,0 @@
-../.agents/skills/critique

--- a/skills/delight
+++ b/skills/delight
@@ -1,1 +1,0 @@
-../.agents/skills/delight

--- a/skills/distill
+++ b/skills/distill
@@ -1,1 +1,0 @@
-../.agents/skills/distill

--- a/skills/extract
+++ b/skills/extract
@@ -1,1 +1,0 @@
-../.agents/skills/extract

--- a/skills/harden
+++ b/skills/harden
@@ -1,1 +1,0 @@
-../.agents/skills/harden

--- a/skills/mermaid-diagrams
+++ b/skills/mermaid-diagrams
@@ -1,1 +1,0 @@
-../.agents/skills/mermaid-diagrams

--- a/skills/normalize
+++ b/skills/normalize
@@ -1,1 +1,0 @@
-../.agents/skills/normalize

--- a/skills/onboard
+++ b/skills/onboard
@@ -1,1 +1,0 @@
-../.agents/skills/onboard

--- a/skills/optimize
+++ b/skills/optimize
@@ -1,1 +1,0 @@
-../.agents/skills/optimize

--- a/skills/polish
+++ b/skills/polish
@@ -1,1 +1,0 @@
-../.agents/skills/polish

--- a/skills/python-design-patterns
+++ b/skills/python-design-patterns
@@ -1,1 +1,0 @@
-../.agents/skills/python-design-patterns

--- a/skills/quieter
+++ b/skills/quieter
@@ -1,1 +1,0 @@
-../.agents/skills/quieter

--- a/skills/tailwind-design-system
+++ b/skills/tailwind-design-system
@@ -1,1 +1,0 @@
-../.agents/skills/tailwind-design-system

--- a/skills/teach-impeccable
+++ b/skills/teach-impeccable
@@ -1,1 +1,0 @@
-../.agents/skills/teach-impeccable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified `.gitignore` configuration by removing redundant directory exclusion entries.
  * Removed multiple skill modules from the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->