### PR TITLE
feat(commons): add call expression match policy

### DIFF
--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/__init__.py
@@ -6,6 +6,7 @@ Contains models and utilities for code analysis and representation.
 from unoplat_code_confluence_commons.base_models import (
     AnnotationLikeInfo,
     CallExpressionInfo,
+    CallExpressionMatchPolicy,
     CodebaseConfig,
     CodebaseConfigSQLModel,
     Concept,
@@ -73,6 +74,7 @@ __all__ = [
     "TargetLevel",
     "LocatorStrategy",
     "Concept",
+    "CallExpressionMatchPolicy",
     "ConstructQueryConfig",
     "FeatureSpec",
     "FeatureUsagePayload",

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/__init__.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/__init__.py
@@ -9,6 +9,7 @@ from unoplat_code_confluence_commons.base_models.data_model_position import (
 from unoplat_code_confluence_commons.base_models.engine_models import (
     AnnotationLikeInfo,
     CallExpressionInfo,
+    CallExpressionMatchPolicy,
     Concept,
     ConstructQueryConfig,
     Detection,
@@ -28,11 +29,11 @@ from unoplat_code_confluence_commons.base_models.framework_models import (
     Framework,
     FrameworkFeature,
 )
+
 # SQL Base class
 from unoplat_code_confluence_commons.base_models.sql_base import (
     SQLBase,
 )
-
 from unoplat_code_confluence_commons.configuration_models import (
     CodebaseConfig,
     RepositorySettings,
@@ -71,6 +72,7 @@ __all__ = [
     "TargetLevel",
     "LocatorStrategy",
     "Concept",
+    "CallExpressionMatchPolicy",
     "ConstructQueryConfig",
     "FeatureSpec",
     "FrameworkFeaturePayload",

--- a/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/engine_models.py
+++ b/unoplat-code-confluence-commons/src/unoplat_code_confluence_commons/base_models/engine_models.py
@@ -43,6 +43,13 @@ class ValidationStatus(str, Enum):
     NEEDS_REVIEW = "needs_review"
 
 
+class CallExpressionMatchPolicy(str, Enum):
+    """Post-query matching policy for CallExpression framework features."""
+
+    MATCH_CALLEE = "match_callee"
+    IMPORT_GUARDED_REGEX = "import_guarded_regex"
+
+
 # ──────────────────────────────────────────────
 # 🔄 Typed models for construct_query structure
 # ──────────────────────────────────────────────
@@ -51,6 +58,10 @@ class ValidationStatus(str, Enum):
 class ConstructQueryConfig(BaseModel):
     """Typed construct query configuration matching JSON schema structure."""
 
+    match_policy: CallExpressionMatchPolicy = Field(
+        default=CallExpressionMatchPolicy.MATCH_CALLEE,
+        description="Post-query matching policy for CallExpression features",
+    )
     method_regex: Optional[str] = Field(
         None, description="Regex for method names (AnnotationLike)"
     )
@@ -75,6 +86,18 @@ class ConstructQueryConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    @model_validator(mode="after")
+    def validate_import_guarded_regex(self) -> Self:
+        """Require an explicit callee regex for regex-only call matching."""
+        if (
+            self.match_policy == CallExpressionMatchPolicy.IMPORT_GUARDED_REGEX
+            and (self.callee_regex is None or not self.callee_regex.strip())
+        ):
+            raise ValueError(
+                "import_guarded_regex match_policy requires a non-empty callee_regex"
+            )
+        return self
+
 
 def _validate_base_confidence_scope(
     concept: Concept,
@@ -89,6 +112,19 @@ def _validate_base_confidence_scope(
         raise ValueError(
             "base_confidence is supported only for CallExpression features"
         )
+
+
+def _validate_match_policy_scope(
+    concept: Concept,
+    construct_query: Dict[str, Any] | None,
+) -> None:
+    if construct_query is None or "match_policy" not in construct_query:
+        return
+    if concept != Concept.CALL_EXPRESSION:
+        raise ValueError(
+            "construct_query.match_policy is supported only for CallExpression features"
+        )
+    ConstructQueryConfig.model_validate(construct_query)
 
 
 def _compose_feature_key(capability_key: str, operation_key: str) -> str:
@@ -164,8 +200,9 @@ class FeatureSpec(BaseModel):
         return _compose_feature_key(self.capability_key, self.operation_key)
 
     @model_validator(mode="after")
-    def validate_base_confidence_scope(self) -> Self:
+    def validate_call_expression_fields(self) -> Self:
         _validate_base_confidence_scope(self.concept, self.base_confidence)
+        _validate_match_policy_scope(self.concept, self.construct_query)
         return self
 
 
@@ -213,8 +250,9 @@ class FrameworkFeaturePayload(BaseModel):
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
 
     @model_validator(mode="after")
-    def validate_base_confidence_scope(self) -> Self:
+    def validate_call_expression_fields(self) -> Self:
         _validate_base_confidence_scope(self.concept, self.base_confidence)
+        _validate_match_policy_scope(self.concept, self.construct_query)
         return self
 
 

--- a/unoplat-code-confluence-commons/tests/test_engine_models.py
+++ b/unoplat-code-confluence-commons/tests/test_engine_models.py
@@ -2,6 +2,7 @@
 
 from pydantic import ValidationError
 from unoplat_code_confluence_commons.base_models import (
+    CallExpressionMatchPolicy,
     Concept,
     ConstructQueryConfig,
     Detection,
@@ -27,6 +28,69 @@ def test_construct_query_config_accepts_function_export_regex_keys() -> None:
 
     assert config.function_name_regex == "^(GET|POST)$"
     assert config.export_name_regex == "^(GET|POST)$"
+
+
+def test_construct_query_config_defaults_to_match_callee_policy() -> None:
+    config = ConstructQueryConfig.model_validate({})
+
+    assert config.match_policy == CallExpressionMatchPolicy.MATCH_CALLEE
+
+
+def test_construct_query_config_accepts_import_guarded_regex_policy() -> None:
+    config = ConstructQueryConfig.model_validate(
+        {"match_policy": "import_guarded_regex", "callee_regex": r"\\.execute$"}
+    )
+
+    assert config.match_policy == CallExpressionMatchPolicy.IMPORT_GUARDED_REGEX
+
+
+def test_construct_query_config_rejects_invalid_match_policy() -> None:
+    try:
+        ConstructQueryConfig.model_validate({"match_policy": "receiver_inference"})
+    except ValidationError as exc:
+        assert "match_policy" in str(exc)
+    else:
+        raise AssertionError("Expected invalid match_policy to fail")
+
+
+def test_import_guarded_regex_policy_requires_callee_regex() -> None:
+    try:
+        ConstructQueryConfig.model_validate(
+            {"match_policy": "import_guarded_regex"}
+        )
+    except ValidationError as exc:
+        assert "requires a non-empty callee_regex" in str(exc)
+    else:
+        raise AssertionError("Expected missing callee_regex to fail")
+
+
+def test_import_guarded_regex_policy_rejects_blank_callee_regex() -> None:
+    try:
+        ConstructQueryConfig.model_validate(
+            {"match_policy": "import_guarded_regex", "callee_regex": "   "}
+        )
+    except ValidationError as exc:
+        assert "requires a non-empty callee_regex" in str(exc)
+    else:
+        raise AssertionError("Expected blank callee_regex to fail")
+
+
+def test_feature_spec_rejects_match_policy_for_non_call_expression() -> None:
+    try:
+        FeatureSpec(
+            capability_key="rest_api",
+            operation_key="route_handler_export",
+            library="nextjs",
+            absolute_paths=["next/server.NextResponse"],
+            target_level=TargetLevel.FUNCTION,
+            concept=Concept.FUNCTION_DEFINITION,
+            locator_strategy=LocatorStrategy.DIRECT,
+            construct_query={"match_policy": "match_callee"},
+        )
+    except ValidationError as exc:
+        assert "supported only for CallExpression" in str(exc)
+    else:
+        raise AssertionError("Expected non-CallExpression match_policy to fail")
 
 
 def test_feature_spec_construct_query_typed_supports_new_regexes() -> None:


### PR DESCRIPTION
this solves capturing instance based methods of particular framework/library

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable matching policies for call-expression queries.
  * Added a default callee-matching policy and an import-guarded regular-expression option.
  * Exposed the new matching policy through the public package API.

* **Bug Fixes**
  * Added validation to require a non-empty callee pattern when using import-guarded matching.
  * Prevented call-expression matching options from being used with unrelated feature types.

* **Tests**
  * Added coverage for defaults, valid and invalid policies, required patterns, and scope validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->